### PR TITLE
Refactor Options.cs

### DIFF
--- a/src/stampver.tests/Options/OptionExceptionTests.cs
+++ b/src/stampver.tests/Options/OptionExceptionTests.cs
@@ -1,5 +1,5 @@
 using System;
-using NDesk.Options;
+using stampver.Options;
 using NUnit.Framework;
 
 namespace stampver.Tests.Options

--- a/src/stampver.tests/Options/OptionExceptionTests.cs
+++ b/src/stampver.tests/Options/OptionExceptionTests.cs
@@ -1,0 +1,84 @@
+using System;
+using NDesk.Options;
+using NUnit.Framework;
+
+namespace stampver.Tests.Options
+{
+    // Pins the observable behaviour of NDesk.Options.OptionException ahead of a
+    // planned modernisation of Options.cs. Serialization (the protected
+    // SerializationInfo ctor and overridden GetObjectData) is intentionally NOT
+    // covered: BinaryFormatter is removed in modern .NET and the SYSLIB0051
+    // diagnostic on those members is already suppressed at the main-project
+    // level. The refactor is expected to drop them entirely.
+    [TestFixture]
+    internal sealed class OptionExceptionTests
+    {
+        [Test]
+        public void DefaultConstructor_LeavesOptionNameNullAndNoInnerException()
+        {
+            var ex = new OptionException();
+
+            Assert.That(ex.OptionName, Is.Null);
+            Assert.That(ex.InnerException, Is.Null);
+        }
+
+        [Test]
+        public void MessageAndOptionNameConstructor_PopulatesBothAndLeavesInnerExceptionNull()
+        {
+            var ex = new OptionException("Missing required value for option '--foo'.", "--foo");
+
+            Assert.That(ex.Message, Is.EqualTo("Missing required value for option '--foo'."));
+            Assert.That(ex.OptionName, Is.EqualTo("--foo"));
+            Assert.That(ex.InnerException, Is.Null);
+        }
+
+        [Test]
+        public void FullConstructor_PopulatesMessageOptionNameAndInnerException()
+        {
+            var inner = new InvalidOperationException("conversion failed");
+
+            var ex = new OptionException("Could not convert value.", "--count", inner);
+
+            Assert.That(ex.Message, Is.EqualTo("Could not convert value."));
+            Assert.That(ex.OptionName, Is.EqualTo("--count"));
+            Assert.That(ex.InnerException, Is.SameAs(inner));
+        }
+
+        [Test]
+        public void Constructor_AcceptsNullOptionName()
+        {
+            // The library uses string.Empty for "no option" in some Parse paths but
+            // accepts a null OptionName too. Refactor must preserve the null-tolerant
+            // contract — callers (including stampver itself) pass string.Empty here,
+            // but third-party callers may pass null.
+            var ex = new OptionException("boom", optionName: null!);
+
+            Assert.That(ex.OptionName, Is.Null);
+        }
+
+        [Test]
+        public void OptionException_IsThrowableAndCarriesOptionNameThroughCatch()
+        {
+            // End-to-end: throw and catch as Exception, downcast, read OptionName.
+            // Pins the production usage pattern in Stampver.TryParseArguments.
+            try
+            {
+                throw new OptionException("nope", "-x");
+            }
+            catch (OptionException caught)
+            {
+                Assert.That(caught.Message, Is.EqualTo("nope"));
+                Assert.That(caught.OptionName, Is.EqualTo("-x"));
+            }
+        }
+
+        [Test]
+        public void OptionException_IsAssignableToException()
+        {
+            // Pins the public type hierarchy. The catch in Stampver.TryParseArguments
+            // narrows on OptionException specifically; downstream consumers may catch
+            // System.Exception. Both must continue to work post-refactor.
+            Assert.That(new OptionException(), Is.InstanceOf<Exception>());
+        }
+    }
+}

--- a/src/stampver.tests/Options/OptionPrototypeTests.cs
+++ b/src/stampver.tests/Options/OptionPrototypeTests.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using NDesk.Options;
+using NUnit.Framework;
+
+namespace stampver.Tests.Options
+{
+    // Pins the Option ctor validation guards and ParsePrototype behaviour.
+    // Option is abstract, so every test constructs CapturingOption — a minimal
+    // subclass that records what OnParseComplete sees, which doubles for the
+    // Invoke() lifecycle assertions at the end of the file.
+    [TestFixture]
+    internal sealed class OptionPrototypeTests
+    {
+        private sealed class CapturingOption : Option
+        {
+            public CapturingOption(string prototype) : base(prototype, null!) { }
+            public CapturingOption(string prototype, string description) : base(prototype, description) { }
+            public CapturingOption(string prototype, string description, int maxValueCount)
+                : base(prototype, description, maxValueCount) { }
+
+            public int InvokeCount;
+            public string? CapturedOptionName;
+            public Option? CapturedOption;
+            public readonly List<string> CapturedValues = new();
+
+            protected override void OnParseComplete(OptionContext c)
+            {
+                InvokeCount++;
+                CapturedOptionName = c.OptionName;
+                CapturedOption = c.Option;
+                CapturedValues.AddRange(c.OptionValues.ToList());
+            }
+        }
+
+        #region Constructor argument validation
+
+        [Test]
+        public void Constructor_WithNullPrototype_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CapturingOption(null!));
+        }
+
+        [Test]
+        public void Constructor_WithEmptyPrototype_ThrowsArgumentExceptionWithDescriptiveMessage()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption(string.Empty))!;
+            Assert.That(ex.Message, Does.StartWith("Cannot be the empty string."));
+            Assert.That(ex.ParamName, Is.EqualTo("prototype"));
+        }
+
+        [Test]
+        public void Constructor_WithNegativeMaxValueCount_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CapturingOption("name", null!, -1));
+        }
+
+        [Test]
+        public void Constructor_WithMaxValueCountZeroAndRequiredType_Throws()
+        {
+            // Pinning the friendly message — refactor must keep the diagnostic legible.
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("name=", null!, 0))!;
+            Assert.That(ex.Message, Does.Contain("Cannot provide maxValueCount of 0"));
+        }
+
+        [Test]
+        public void Constructor_WithMaxValueCountZeroAndOptionalType_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("name:", null!, 0))!;
+            Assert.That(ex.Message, Does.Contain("Cannot provide maxValueCount of 0"));
+        }
+
+        [Test]
+        public void Constructor_WithMaxValueCountZeroAndNoType_Succeeds()
+        {
+            // count=0 + None type is the one combination NDesk allows.
+            var option = new CapturingOption("name", null!, 0);
+
+            Assert.That(option.MaxValueCount, Is.EqualTo(0));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.None));
+        }
+
+        [Test]
+        public void Constructor_WithNoTypeAndMaxValueCountGreaterThanOne_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("name", null!, 2))!;
+            Assert.That(ex.Message, Does.Contain("Cannot provide maxValueCount of 2 for OptionValueType.None"));
+        }
+
+        #endregion
+
+        #region Default handler "<>" rules
+
+        [Test]
+        public void Constructor_WithSoloDefaultHandlerAndRequiredType_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("<>="))!;
+            Assert.That(ex.Message, Does.Contain("default option handler '<>' cannot require values"));
+        }
+
+        [Test]
+        public void Constructor_WithSoloDefaultHandlerAndOptionalType_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new CapturingOption("<>:"));
+        }
+
+        [Test]
+        public void Constructor_WithSoloDefaultHandlerAndNoType_Succeeds()
+        {
+            // "<>" alone is a valid no-value handler — the Parse path uses it as
+            // the destination for unmatched arguments.
+            var option = new CapturingOption("<>");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "<>" }));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.None));
+        }
+
+        [Test]
+        public void Constructor_WithDefaultHandlerAliasAndSingleValue_Succeeds()
+        {
+            // "<>" can co-exist with a sibling alias provided the option only
+            // takes a single value.
+            var option = new CapturingOption("<>|name=", null!, 1);
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "<>", "name" }));
+            Assert.That(option.MaxValueCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Constructor_WithDefaultHandlerAliasAndMultipleValues_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("<>|name=", null!, 2))!;
+            Assert.That(ex.Message, Does.Contain("default option handler '<>' cannot require values"));
+        }
+
+        #endregion
+
+        #region Prototype parsing — types and aliases
+
+        [Test]
+        public void Constructor_PlainNameWithNoTerminator_ProducesNoneType()
+        {
+            var option = new CapturingOption("verbose");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "verbose" }));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.None));
+        }
+
+        [Test]
+        public void Constructor_NameEndingInEquals_ProducesRequiredType()
+        {
+            var option = new CapturingOption("name=");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "name" }));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.Required));
+        }
+
+        [Test]
+        public void Constructor_NameEndingInColon_ProducesOptionalType()
+        {
+            var option = new CapturingOption("name:");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "name" }));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.Optional));
+        }
+
+        [Test]
+        public void Constructor_PipeDelimitedAliases_StripsTerminatorFromEachName()
+        {
+            var option = new CapturingOption("h|?|help");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "h", "?", "help" }));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.None));
+        }
+
+        [Test]
+        public void Constructor_TypeOnSingleAliasAppliesToWholeOption()
+        {
+            // The terminator only needs to appear on one alias for the option
+            // to be Required/Optional. This is documented behaviour.
+            var option = new CapturingOption("a|b=");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { "a", "b" }));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.Required));
+        }
+
+        [Test]
+        public void Constructor_ConsistentTypeOnMultipleAliasesIsAccepted()
+        {
+            var option = new CapturingOption("a=|b=");
+
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.Required));
+        }
+
+        [Test]
+        public void Constructor_ConflictingTypesAcrossAliases_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("a=|b:"))!;
+            Assert.That(ex.Message, Does.Contain("Conflicting option types"));
+        }
+
+        [Test]
+        public void Constructor_EmptyAliasInMiddle_Throws()
+        {
+            // "a||b" splits into ["a", "", "b"] — the empty alias is rejected.
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("a||b"))!;
+            Assert.That(ex.Message, Does.StartWith("Empty option names are not supported."));
+        }
+
+        [Test]
+        public void Constructor_PrototypeOfJustPipe_Throws()
+        {
+            // "|" splits into ["", ""] — both aliases are empty.
+            Assert.Throws<ArgumentException>(() => new CapturingOption("|"));
+        }
+
+        [Test]
+        public void Constructor_WhitespaceOnlyPrototype_IsAccepted()
+        {
+            // Quirk: " " has length 1, so the empty-string guard doesn't fire.
+            // The space becomes the option's literal name. Pinning so the
+            // refactor decides whether to keep this loophole.
+            var option = new CapturingOption(" ");
+
+            Assert.That(option.GetNames(), Is.EqualTo(new[] { " " }));
+        }
+
+        #endregion
+
+        #region Prototype parsing — separators
+
+        [Test]
+        public void Constructor_SeparatorWithMaxValueCountOne_Throws()
+        {
+            // Separators are only meaningful when an option takes >1 value.
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("name=,"))!;
+            Assert.That(ex.Message, Does.Contain("Cannot provide key/value separators"));
+        }
+
+        [Test]
+        public void Constructor_DefaultSeparatorsApplyWhenNoneSpecifiedAndMaxValueCountGreaterThanOne()
+        {
+            var option = new CapturingOption("name=", null!, 2);
+
+            Assert.That(option.GetValueSeparators(), Is.EqualTo(new[] { ":", "=" }));
+        }
+
+        [Test]
+        public void Constructor_SinglePunctuationSeparator_IsCapturedVerbatim()
+        {
+            var option = new CapturingOption("name=,", null!, 2);
+
+            Assert.That(option.GetValueSeparators(), Is.EqualTo(new[] { "," }));
+        }
+
+        [Test]
+        public void Constructor_MultiCharSeparatorViaCurlyBraces_IsCapturedAsSingleSeparator()
+        {
+            // "{,;}" is ONE separator literal ",;", not two single-char separators.
+            // This is the only way to declare a multi-character separator.
+            var option = new CapturingOption("name={,;}", null!, 2);
+
+            Assert.That(option.GetValueSeparators(), Is.EqualTo(new[] { ",;" }));
+        }
+
+        [Test]
+        public void Constructor_EmptyCurlyBraceSeparator_DisablesSplittingEntirely()
+        {
+            // "{}" is the documented way to opt out of value splitting altogether
+            // — values must be passed as separate argv tokens. The implementation
+            // signals this by setting the internal separators field to null,
+            // which surfaces as an empty array via GetValueSeparators.
+            var option = new CapturingOption("name={}", null!, 2);
+
+            Assert.That(option.GetValueSeparators(), Is.Empty);
+        }
+
+        [Test]
+        public void Constructor_UnbalancedOpenBraceSeparator_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("name={", null!, 2))!;
+            Assert.That(ex.Message, Does.Contain("Ill-formed name/value separator"));
+        }
+
+        [Test]
+        public void Constructor_UnbalancedCloseBraceSeparator_Throws()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new CapturingOption("name=}", null!, 2))!;
+            Assert.That(ex.Message, Does.Contain("Ill-formed name/value separator"));
+        }
+
+        [Test]
+        public void Constructor_NestedOpenBraceInSeparator_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new CapturingOption("name={a{b}", null!, 2));
+        }
+
+        #endregion
+
+        #region Property accessors
+
+        [Test]
+        public void Prototype_ReturnsExactStringPassedToConstructor()
+        {
+            // Prototype is the raw input — terminators and separators stay attached,
+            // even though Names strips them.
+            var option = new CapturingOption("name=,", null!, 2);
+
+            Assert.That(option.Prototype, Is.EqualTo("name=,"));
+        }
+
+        [Test]
+        public void Description_DefaultsToNullWhenOmitted()
+        {
+            var option = new CapturingOption("name");
+
+            Assert.That(option.Description, Is.Null);
+        }
+
+        [Test]
+        public void Description_ReflectsConstructorArgument()
+        {
+            var option = new CapturingOption("name", "describe");
+
+            Assert.That(option.Description, Is.EqualTo("describe"));
+        }
+
+        [Test]
+        public void MaxValueCount_DefaultsToOneInTwoArgConstructor()
+        {
+            // The (prototype, description) overload chains to (prototype, description, 1).
+            var option = new CapturingOption("name=", "desc");
+
+            Assert.That(option.MaxValueCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ToString_ReturnsPrototype()
+        {
+            var option = new CapturingOption("a|b=");
+
+            Assert.That(option.ToString(), Is.EqualTo("a|b="));
+        }
+
+        [Test]
+        public void GetNames_ReturnsACopyDecoupledFromTheOption()
+        {
+            var option = new CapturingOption("a|b|c");
+
+            var names = option.GetNames();
+            names[0] = "tampered";
+
+            Assert.That(option.GetNames()[0], Is.EqualTo("a"));
+        }
+
+        [Test]
+        public void GetValueSeparators_OnNoneTypeOption_ReturnsEmptyArray()
+        {
+            var option = new CapturingOption("verbose");
+
+            Assert.That(option.GetValueSeparators(), Is.Empty);
+        }
+
+        [Test]
+        public void GetValueSeparators_ReturnsACopyDecoupledFromTheOption()
+        {
+            var option = new CapturingOption("name=,;", null!, 2);
+
+            var seps = option.GetValueSeparators();
+            seps[0] = "X";
+
+            Assert.That(option.GetValueSeparators()[0], Is.Not.EqualTo("X"));
+        }
+
+        #endregion
+
+        #region Invoke lifecycle
+
+        [Test]
+        public void Invoke_CallsOnParseCompleteThenClearsContextState()
+        {
+            // Invoke runs the user-supplied callback (OnParseComplete) and then
+            // resets the context so the next argument starts clean. Pinning so
+            // the refactor doesn't accidentally swap the order or skip the reset.
+            var set = new OptionSet();
+            var option = new CapturingOption("name=");
+            set.Add(option);
+
+            var context = new OptionContext(set) { Option = option, OptionName = "--name" };
+            context.OptionValues.Add("payload");
+
+            option.Invoke(context);
+
+            Assert.That(option.InvokeCount, Is.EqualTo(1));
+            Assert.That(option.CapturedOptionName, Is.EqualTo("--name"));
+            Assert.That(option.CapturedOption, Is.SameAs(option));
+            Assert.That(option.CapturedValues, Is.EqualTo(new[] { "payload" }));
+
+            // Post-invoke, the context is cleared.
+            Assert.That(context.Option, Is.Null);
+            Assert.That(context.OptionName, Is.Null);
+            Assert.That(context.OptionValues.Count, Is.EqualTo(0));
+        }
+
+        #endregion
+    }
+}

--- a/src/stampver.tests/Options/OptionPrototypeTests.cs
+++ b/src/stampver.tests/Options/OptionPrototypeTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using NDesk.Options;
+using stampver.Options;
 using NUnit.Framework;
 
 namespace stampver.Tests.Options

--- a/src/stampver.tests/Options/OptionSetAddTests.cs
+++ b/src/stampver.tests/Options/OptionSetAddTests.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Linq;
+using NDesk.Options;
+using NUnit.Framework;
+
+namespace stampver.Tests.Options
+{
+    // Pins every Add overload, KeyedCollection-derived lookup behaviour, the
+    // localizer plumbing, and the typed Add<T>/Add<TKey,TValue> conversion paths.
+    // The cross-culture tests near the bottom highlight the locale-coupling
+    // baked into TypeDescriptor.GetConverter — exactly the kind of hidden
+    // behaviour the refactor will need to make explicit.
+    [TestFixture]
+    internal sealed class OptionSetAddTests
+    {
+        #region Constructors and localizer
+
+        [Test]
+        public void DefaultConstructor_ProvidesIdentityLocalizer()
+        {
+            var set = new OptionSet();
+
+            // The default localizer round-trips its input unchanged. Pin so the
+            // refactor doesn't accidentally substitute a "translate" stub.
+            Assert.That(set.MessageLocalizer("hello"), Is.EqualTo("hello"));
+            Assert.That(set.MessageLocalizer(string.Empty), Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void CustomLocalizerConstructor_ExposesTheSameDelegateInstance()
+        {
+            Converter<string, string> localizer = s => $"[{s}]";
+
+            var set = new OptionSet(localizer);
+
+            Assert.That(set.MessageLocalizer, Is.SameAs(localizer));
+            Assert.That(set.MessageLocalizer("x"), Is.EqualTo("[x]"));
+        }
+
+        #endregion
+
+        #region Add(Option)
+
+        [Test]
+        public void AddOption_ReturnsSameOptionSetToEnableChaining()
+        {
+            var set = new OptionSet();
+            var first = MakeOption("a");
+            var second = MakeOption("b");
+
+            var returned = set.Add(first).Add(second);
+
+            Assert.That(returned, Is.SameAs(set));
+            Assert.That(set.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void AddOption_WithNull_Throws()
+        {
+            var set = new OptionSet();
+
+            // KeyedCollection allows null insertion at the base; OptionSet's
+            // override (AddImpl) is what catches it. Pin so the refactor doesn't
+            // drop the null-guard and leak nulls into the collection.
+            Assert.Throws<ArgumentNullException>(() => set.Add((Option)null!));
+        }
+
+        [Test]
+        public void AddOption_RegistersEveryAliasInTheKeyedCollection()
+        {
+            var set = new OptionSet();
+            var option = MakeOption("h|?|help");
+
+            set.Add(option);
+
+            Assert.That(set.Contains("h"), Is.True);
+            Assert.That(set.Contains("?"), Is.True);
+            Assert.That(set.Contains("help"), Is.True);
+            Assert.That(set["h"], Is.SameAs(option));
+            Assert.That(set["?"], Is.SameAs(option));
+            Assert.That(set["help"], Is.SameAs(option));
+        }
+
+        [Test]
+        public void AddOption_ContainsForUnknownName_ReturnsFalse()
+        {
+            var set = new OptionSet { MakeOption("known") };
+
+            Assert.That(set.Contains("unknown"), Is.False);
+        }
+
+        #endregion
+
+        #region Add(prototype, Action<string>) — single-value untyped
+
+        [Test]
+        public void AddPrototypeAction_RegistersOptionWithMaxValueCountOne()
+        {
+            var set = new OptionSet { { "name=", _ => { } } };
+
+            var option = set["name"];
+            Assert.That(option.MaxValueCount, Is.EqualTo(1));
+            Assert.That(option.OptionValueType, Is.EqualTo(OptionValueType.Required));
+        }
+
+        [Test]
+        public void AddPrototypeAction_DefaultsDescriptionToNull()
+        {
+            var set = new OptionSet { { "name=", _ => { } } };
+
+            Assert.That(set["name"].Description, Is.Null);
+        }
+
+        [Test]
+        public void AddPrototypeDescriptionAction_PreservesDescription()
+        {
+            var set = new OptionSet { { "name=", "the name", _ => { } } };
+
+            Assert.That(set["name"].Description, Is.EqualTo("the name"));
+        }
+
+        [Test]
+        public void AddPrototypeAction_WithNullAction_Throws()
+        {
+            var set = new OptionSet();
+
+            Assert.Throws<ArgumentNullException>(() => set.Add("name=", (Action<string>)null!));
+        }
+
+        [Test]
+        public void AddPrototypeAction_InvokesActionDuringParse()
+        {
+            string? captured = null;
+            var set = new OptionSet { { "name=", v => captured = v } };
+
+            set.Parse(new[] { "--name=value" });
+
+            Assert.That(captured, Is.EqualTo("value"));
+        }
+
+        #endregion
+
+        #region Add(prototype, OptionAction<string,string>) — two-value untyped
+
+        [Test]
+        public void AddPrototypeOptionAction_RegistersOptionWithMaxValueCountTwo()
+        {
+            var set = new OptionSet { { "p=", (k, v) => { _ = k; _ = v; } } };
+
+            Assert.That(set["p"].MaxValueCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void AddPrototypeOptionAction_WithNullAction_Throws()
+        {
+            var set = new OptionSet();
+
+            Assert.Throws<ArgumentNullException>(() => set.Add("p=", (OptionAction<string, string>)null!));
+        }
+
+        [Test]
+        public void AddPrototypeOptionAction_ReceivesBothValuesDuringParse()
+        {
+            string? key = null;
+            string? value = null;
+            var set = new OptionSet { { "D=", (k, v) => { key = k; value = v; } } };
+
+            set.Parse(new[] { "-Dkey=val" });
+
+            Assert.That(key, Is.EqualTo("key"));
+            Assert.That(value, Is.EqualTo("val"));
+        }
+
+        #endregion
+
+        #region Add<T> — typed conversions
+
+        [Test]
+        public void AddTypedAction_ConvertsStringToTargetTypeViaTypeConverter()
+        {
+            int captured = 0;
+            var set = new OptionSet { { "count=", (int v) => captured = v } };
+
+            set.Parse(new[] { "--count=42" });
+
+            Assert.That(captured, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void AddTypedAction_OnConversionFailure_ThrowsOptionExceptionWithInnerException()
+        {
+            var set = new OptionSet { { "count=", (int _) => { } } };
+
+            var ex = Assert.Throws<OptionException>(() => set.Parse(new[] { "--count=notanumber" }))!;
+            Assert.That(ex.OptionName, Is.EqualTo("--count"));
+            Assert.That(ex.InnerException, Is.Not.Null,
+                "Pin: the conversion exception is preserved as the InnerException so callers can diagnose root cause.");
+            Assert.That(ex.Message, Does.Contain("Could not convert"));
+        }
+
+        [Test]
+        public void AddTypedAction_WithNullAction_Throws()
+        {
+            // The wrapping ActionOption<T> ctor enforces non-null action.
+            var set = new OptionSet();
+
+            Assert.Throws<ArgumentNullException>(() => set.Add("count=", (Action<int>)null!));
+        }
+
+        [Test]
+        public void AddTypedOptionAction_ReceivesBothValuesConvertedToTargetTypes()
+        {
+            string? capturedKey = null;
+            int capturedValue = 0;
+            var set = new OptionSet { { "p=", (string k, int v) => { capturedKey = k; capturedValue = v; } } };
+
+            set.Parse(new[] { "-pkey=7" });
+
+            Assert.That(capturedKey, Is.EqualTo("key"));
+            Assert.That(capturedValue, Is.EqualTo(7));
+        }
+
+        #endregion
+
+        #region Cross-culture quirk pinning
+
+        [Test]
+        [SetCulture("tr-TR")]
+        public void AddTypedAction_DoubleConversion_UsesCurrentCultureForParsing()
+        {
+            // QUIRK: Parse<T> calls TypeConverter.ConvertFromString without an
+            // explicit CultureInfo, which defaults to CultureInfo.CurrentCulture.
+            // In tr-TR the decimal separator is ',', so "1,5" parses as 1.5.
+            // In invariant culture the same input would either fail or be
+            // mis-parsed. The modernised parser should make this an explicit
+            // choice (most likely InvariantCulture) — pinning the current
+            // locale-coupled behaviour so the swap is visible.
+            double captured = 0;
+            var set = new OptionSet { { "ratio=", (double v) => captured = v } };
+
+            set.Parse(new[] { "--ratio=1,5" });
+
+            Assert.That(captured, Is.EqualTo(1.5));
+        }
+
+        #endregion
+
+        #region KeyedCollection lookup and removal
+
+        [Test]
+        public void Indexer_ForUnknownKey_ThrowsKeyNotFoundException()
+        {
+            var set = new OptionSet();
+
+            // Inherited from KeyedCollection — pin so callers (or the refactor)
+            // know the indexer doesn't return null on a miss.
+            Assert.Throws<System.Collections.Generic.KeyNotFoundException>(() => _ = set["missing"]);
+        }
+
+        [Test]
+        public void Remove_OnSoleOptionInSet_ThrowsArgumentOutOfRangeException_KnownBug()
+        {
+            // KNOWN BUG. OptionSet.RemoveItem(index) calls base.RemoveItem(index)
+            // FIRST and then dereferences Items[index] to find the alias names —
+            // but the item has already been removed, so Items[index] is either
+            // out of range (this case) or the wrong option (test below).
+            // Pinning the current observable behaviour so the modernisation
+            // refactor surfaces an explicit fix (capture names BEFORE removal).
+            var set = new OptionSet { { "h|?|help", _ => { } } };
+            var option = set["h"];
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => set.Remove(option));
+        }
+
+        [Test]
+        public void Remove_OptionWithAliasesAndTrailingItem_LeavesStaleAliasEntries_KnownBug()
+        {
+            // Continuation of the bug pinned above: when a following option
+            // exists, RemoveItem reads its Names instead of the removed option's,
+            // so the original option's alias entries stay live in the lookup
+            // dictionary. KeyedCollection still removes the FIRST name correctly
+            // because that path runs inside base.RemoveItem before the broken
+            // post-call dereference.
+            var set = new OptionSet
+            {
+                { "h|?|help", _ => { } },
+                { "v", _ => { } },
+            };
+            var helpOption = set["h"];
+
+            set.Remove(helpOption);
+
+            Assert.That(set.Contains("h"), Is.False, "first name is correctly removed by base.RemoveItem.");
+            Assert.That(set.Contains("?"), Is.True, "stale alias — refactor target.");
+            Assert.That(set.Contains("help"), Is.True, "stale alias — refactor target.");
+        }
+
+        [Test]
+        public void Remove_AliaslessOptionWithTrailingItem_RemovesCleanly()
+        {
+            // Sanity check: when the removed option has no aliases, the buggy
+            // post-removal dereference walks an empty loop body, so the dictionary
+            // ends up consistent. This is the only Remove path that currently works.
+            var set = new OptionSet
+            {
+                { "first", _ => { } },
+                { "second", _ => { } },
+            };
+            var firstOption = set["first"];
+
+            set.Remove(firstOption);
+
+            Assert.That(set.Contains("first"), Is.False);
+            Assert.That(set.Contains("second"), Is.True);
+        }
+
+        [Test]
+        public void Add_DuplicateAliasAcrossOptions_Throws()
+        {
+            var set = new OptionSet { { "name=", _ => { } } };
+
+            // Pin: alias collisions are surfaced eagerly, not lazily at parse time.
+            // The exact exception type isn't documented — pinning that *something*
+            // throws so the modernised implementation has a freedom-versus-contract
+            // checkpoint here.
+            Assert.That(() => set.Add("name=", _ => { }), Throws.Exception);
+        }
+
+        [Test]
+        public void OptionSet_IsEnumerableInInsertionOrder()
+        {
+            var set = new OptionSet
+            {
+                { "a", _ => { } },
+                { "b", _ => { } },
+                { "c", _ => { } },
+            };
+
+            // OptionSet inherits IEnumerable<Option> from Collection<T>; the
+            // WriteOptionDescriptions code path depends on insertion order.
+            Assert.That(set.Select(o => o.Prototype).ToArray(), Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        #endregion
+
+        private static ActionOption MakeOption(string prototype) => new(prototype);
+
+        // Tiny test-only Option subclass to feed Add(Option). The action-based
+        // Add overloads cover the everyday paths; this exists purely to give the
+        // Option-based overload coverage without duplicating a full subclass per file.
+        private sealed class ActionOption : Option
+        {
+            public ActionOption(string prototype) : base(prototype, null!) { }
+            protected override void OnParseComplete(OptionContext c) { }
+        }
+    }
+}

--- a/src/stampver.tests/Options/OptionSetAddTests.cs
+++ b/src/stampver.tests/Options/OptionSetAddTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
-using NDesk.Options;
 using NUnit.Framework;
+using stampver.Options;
 
 namespace stampver.Tests.Options
 {
@@ -29,7 +29,7 @@ namespace stampver.Tests.Options
         [Test]
         public void CustomLocalizerConstructor_ExposesTheSameDelegateInstance()
         {
-            Converter<string, string> localizer = s => $"[{s}]";
+            Func<string, string> localizer = s => $"[{s}]";
 
             var set = new OptionSet(localizer);
 
@@ -155,7 +155,7 @@ namespace stampver.Tests.Options
         {
             var set = new OptionSet();
 
-            Assert.Throws<ArgumentNullException>(() => set.Add("p=", (OptionAction<string, string>)null!));
+            Assert.Throws<ArgumentNullException>(() => set.Add("p=", (Action<string, string>)null!));
         }
 
         [Test]
@@ -222,25 +222,37 @@ namespace stampver.Tests.Options
 
         #endregion
 
-        #region Cross-culture quirk pinning
+        #region Locale-independent typed conversion
 
         [Test]
-        [SetCulture("tr-TR")]
-        public void AddTypedAction_DoubleConversion_UsesCurrentCultureForParsing()
+        public void AddTypedAction_DoubleConversion_UsesInvariantCultureRegardlessOfDefaultLocale()
         {
-            // QUIRK: Parse<T> calls TypeConverter.ConvertFromString without an
-            // explicit CultureInfo, which defaults to CultureInfo.CurrentCulture.
-            // In tr-TR the decimal separator is ',', so "1,5" parses as 1.5.
-            // In invariant culture the same input would either fail or be
-            // mis-parsed. The modernised parser should make this an explicit
-            // choice (most likely InvariantCulture) — pinning the current
-            // locale-coupled behaviour so the swap is visible.
+            // Phase 0 modernisation: Parse<T> now passes CultureInfo.InvariantCulture
+            // explicitly to TypeConverter.ConvertFromString. The original NDesk
+            // implementation defaulted to CurrentCulture and so silently produced
+            // different parse results depending on the user's locale. Invariant
+            // is the correct default for parsing command-line arguments.
             double captured = 0;
             var set = new OptionSet { { "ratio=", (double v) => captured = v } };
 
-            set.Parse(new[] { "--ratio=1,5" });
+            set.Parse(new[] { "--ratio=1.5" });
 
             Assert.That(captured, Is.EqualTo(1.5));
+        }
+
+        [Test]
+        [SetCulture("tr-TR")]
+        public void AddTypedAction_DoubleConversion_TurkishCommaDecimalIsRejectedUnderInvariantParsing()
+        {
+            // Companion to the test above: under tr-TR, the decimal separator
+            // is ',', and the original NDesk parser accepted "1,5". The Phase 0
+            // switch to InvariantCulture means "1,5" no longer parses as 1.5
+            // and surfaces a normal conversion failure. Pinning the new shape.
+            var set = new OptionSet { { "ratio=", (double _) => { } } };
+
+            var ex = Assert.Throws<OptionException>(() => set.Parse(new[] { "--ratio=1,5" }))!;
+            Assert.That(ex.Message, Does.Contain("Could not convert"));
+            Assert.That(ex.OptionName, Is.EqualTo("--ratio"));
         }
 
         #endregion
@@ -258,29 +270,32 @@ namespace stampver.Tests.Options
         }
 
         [Test]
-        public void Remove_OnSoleOptionInSet_ThrowsArgumentOutOfRangeException_KnownBug()
+        public void Remove_OnSoleOptionInSet_RemovesAllAliasesCleanly()
         {
-            // KNOWN BUG. OptionSet.RemoveItem(index) calls base.RemoveItem(index)
-            // FIRST and then dereferences Items[index] to find the alias names —
-            // but the item has already been removed, so Items[index] is either
-            // out of range (this case) or the wrong option (test below).
-            // Pinning the current observable behaviour so the modernisation
-            // refactor surfaces an explicit fix (capture names BEFORE removal).
+            // Phase 0 bug fix: the original NDesk implementation captured alias
+            // names AFTER calling base.RemoveItem, dereferencing already-removed
+            // storage and either throwing AOORE (this case) or reading a stale
+            // item (the multi-option case below). The modernised Remove captures
+            // names BEFORE removing — all aliases now disappear cleanly.
             var set = new OptionSet { { "h|?|help", _ => { } } };
             var option = set["h"];
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => set.Remove(option));
+            var removed = set.Remove(option);
+
+            Assert.That(removed, Is.True);
+            Assert.That(set.Count, Is.EqualTo(0));
+            Assert.That(set.Contains("h"), Is.False);
+            Assert.That(set.Contains("?"), Is.False);
+            Assert.That(set.Contains("help"), Is.False);
         }
 
         [Test]
-        public void Remove_OptionWithAliasesAndTrailingItem_LeavesStaleAliasEntries_KnownBug()
+        public void Remove_OptionWithAliasesAndTrailingItem_RemovesAllAliasesAndLeavesOtherOptionIntact()
         {
-            // Continuation of the bug pinned above: when a following option
-            // exists, RemoveItem reads its Names instead of the removed option's,
-            // so the original option's alias entries stay live in the lookup
-            // dictionary. KeyedCollection still removes the FIRST name correctly
-            // because that path runs inside base.RemoveItem before the broken
-            // post-call dereference.
+            // Companion to the test above. The original implementation left
+            // stale alias entries ("?" and "help") in the lookup when there was
+            // a trailing item, because it read the WRONG option's names after
+            // the base removal had already shifted indices. Fixed in Phase 0.
             var set = new OptionSet
             {
                 { "h|?|help", _ => { } },
@@ -290,17 +305,15 @@ namespace stampver.Tests.Options
 
             set.Remove(helpOption);
 
-            Assert.That(set.Contains("h"), Is.False, "first name is correctly removed by base.RemoveItem.");
-            Assert.That(set.Contains("?"), Is.True, "stale alias — refactor target.");
-            Assert.That(set.Contains("help"), Is.True, "stale alias — refactor target.");
+            Assert.That(set.Contains("h"), Is.False);
+            Assert.That(set.Contains("?"), Is.False, "all aliases of a removed option must also be removed.");
+            Assert.That(set.Contains("help"), Is.False, "all aliases of a removed option must also be removed.");
+            Assert.That(set.Contains("v"), Is.True, "untouched option must remain registered.");
         }
 
         [Test]
         public void Remove_AliaslessOptionWithTrailingItem_RemovesCleanly()
         {
-            // Sanity check: when the removed option has no aliases, the buggy
-            // post-removal dereference walks an empty loop body, so the dictionary
-            // ends up consistent. This is the only Remove path that currently works.
             var set = new OptionSet
             {
                 { "first", _ => { } },
@@ -315,15 +328,31 @@ namespace stampver.Tests.Options
         }
 
         [Test]
-        public void Add_DuplicateAliasAcrossOptions_Throws()
+        public void Remove_OnOptionNotInSet_ReturnsFalseWithoutThrowing()
         {
+            // Modernised Remove returns bool (matching the BCL convention for
+            // ICollection<T>.Remove and Dictionary.Remove). The original code
+            // had no graceful path for "option not present" — pinning the new
+            // contract so callers know they can probe-then-remove safely.
+            var set = new OptionSet { { "a", _ => { } } };
+            var orphan = set["a"];
+            set.Remove(orphan);
+
+            Assert.That(set.Remove(orphan), Is.False);
+        }
+
+        [Test]
+        public void Add_DuplicateAliasAcrossOptions_ThrowsArgumentExceptionIdentifyingTheConflictingName()
+        {
+            // Phase 0 modernisation: alias collisions throw a specific
+            // ArgumentException whose message contains the conflicting alias.
+            // The original NDesk code threw "something" (the test had to use
+            // Throws.Exception). Tightening lets callers actually diagnose.
             var set = new OptionSet { { "name=", _ => { } } };
 
-            // Pin: alias collisions are surfaced eagerly, not lazily at parse time.
-            // The exact exception type isn't documented — pinning that *something*
-            // throws so the modernised implementation has a freedom-versus-contract
-            // checkpoint here.
-            Assert.That(() => set.Add("name=", _ => { }), Throws.Exception);
+            var ex = Assert.Throws<ArgumentException>(() => set.Add("name=", _ => { }))!;
+            Assert.That(ex.Message, Does.Contain("'name'"),
+                "the diagnostic should identify the conflicting alias.");
         }
 
         [Test]

--- a/src/stampver.tests/Options/OptionSetParseTests.cs
+++ b/src/stampver.tests/Options/OptionSetParseTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using NDesk.Options;
+using stampver.Options;
 using NUnit.Framework;
 
 namespace stampver.Tests.Options
@@ -443,9 +443,9 @@ namespace stampver.Tests.Options
         // separator (the higher-level Add overloads don't expose this knob).
         private sealed class TwoValueOption : Option
         {
-            private readonly OptionAction<string, string> _action;
+            private readonly Action<string, string> _action;
 
-            public TwoValueOption(string prototype, OptionAction<string, string> action)
+            public TwoValueOption(string prototype, Action<string, string> action)
                 : base(prototype, null!, 2)
             {
                 _action = action;

--- a/src/stampver.tests/Options/OptionSetParseTests.cs
+++ b/src/stampver.tests/Options/OptionSetParseTests.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using NDesk.Options;
+using NUnit.Framework;
+
+namespace stampver.Tests.Options
+{
+    // End-to-end argv-shaped scenarios. This is the most behaviour-dense file in
+    // the suite — it covers every parsing path a real CLI hits:
+    //   long/short forms · flag prefixes (-- / - / /) · value separators (= / :)
+    //   space-separated values · bool ± toggles · bundling · -- terminator
+    //   <> default handler · multi-value with separators · error paths
+    [TestFixture]
+    internal sealed class OptionSetParseTests
+    {
+        #region Long-form options
+
+        [Test]
+        public void Parse_LongOptionWithEquals_PassesValueToAction()
+        {
+            string? captured = null;
+            var set = new OptionSet { { "name=", v => captured = v } };
+
+            var unprocessed = set.Parse(new[] { "--name=hello" });
+
+            Assert.That(captured, Is.EqualTo("hello"));
+            Assert.That(unprocessed, Is.Empty);
+        }
+
+        [Test]
+        public void Parse_LongOptionWithColon_PassesValueToAction()
+        {
+            string? captured = null;
+            var set = new OptionSet { { "name=", v => captured = v } };
+
+            set.Parse(new[] { "--name:hello" });
+
+            Assert.That(captured, Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public void Parse_LongOptionFollowedBySeparateValueArg_PassesValueToAction()
+        {
+            string? captured = null;
+            var set = new OptionSet { { "name=", v => captured = v } };
+
+            set.Parse(new[] { "--name", "hello" });
+
+            Assert.That(captured, Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public void Parse_OptionalTypeWithoutValue_InvokesActionWithNull()
+        {
+            // Optional-type options invoke immediately even when no value follows.
+            // The action receives null. Pinning so refactor can't quietly upgrade
+            // this to require a value.
+            string? captured = "<unset>";
+            int invokeCount = 0;
+            var set = new OptionSet
+            {
+                { "name:", v => { captured = v; invokeCount++; } },
+            };
+
+            set.Parse(new[] { "--name" });
+
+            Assert.That(invokeCount, Is.EqualTo(1));
+            Assert.That(captured, Is.Null);
+        }
+
+        #endregion
+
+        #region Flag-prefix variants
+
+        [Test]
+        public void Parse_RecognisesAllThreeFlagPrefixesForLongOptions()
+        {
+            // The regex at OptionSet.ValueOption accepts "--", "-", or "/" as the
+            // flag prefix. All three feed the same option.
+            var captured = new List<string>();
+            var set = new OptionSet { { "name=", v => captured.Add(v) } };
+
+            set.Parse(new[] { "--name=a", "-name=b", "/name=c" });
+
+            Assert.That(captured, Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        #endregion
+
+        #region Bool / no-value options
+
+        [Test]
+        public void Parse_BoolOptionInvokesActionWithStrippedName()
+        {
+            // QUIRK: For OptionValueType.None, the action's value parameter is
+            // the option NAME (without flag prefix), not the original token and
+            // not a literal "true"/null. Refactor likely wants to revisit this.
+            string? captured = null;
+            var set = new OptionSet { { "verbose", v => captured = v } };
+
+            set.Parse(new[] { "--verbose" });
+
+            Assert.That(captured, Is.EqualTo("verbose"));
+        }
+
+        [Test]
+        public void Parse_PlusSuffixOnBoolOption_InvokesActionWithFullOriginalToken()
+        {
+            // QUIRK: for "-a+", the action receives the entire original argv token
+            // (including flag prefix and trailing '+'), not the stripped name.
+            // This asymmetry with the bare-name path above is one of the
+            // observable behaviours flagged for review during modernisation.
+            string? captured = null;
+            var set = new OptionSet { { "a", v => captured = v } };
+
+            set.Parse(new[] { "-a+" });
+
+            Assert.That(captured, Is.EqualTo("-a+"));
+        }
+
+        [Test]
+        public void Parse_MinusSuffixOnBoolOption_InvokesActionWithNull()
+        {
+            string? captured = "<unset>";
+            int invokeCount = 0;
+            var set = new OptionSet { { "a", v => { captured = v; invokeCount++; } } };
+
+            set.Parse(new[] { "-a-" });
+
+            Assert.That(invokeCount, Is.EqualTo(1));
+            Assert.That(captured, Is.Null);
+        }
+
+        #endregion
+
+        #region Bundling (only for the "-" prefix)
+
+        [Test]
+        public void Parse_BundlesMultipleSingleCharBoolOptionsBehindOneDash()
+        {
+            var fired = new List<string>();
+            var set = new OptionSet
+            {
+                { "a", _ => fired.Add("a") },
+                { "b", _ => fired.Add("b") },
+                { "c", _ => fired.Add("c") },
+            };
+
+            set.Parse(new[] { "-abc" });
+
+            Assert.That(fired, Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        [Test]
+        public void Parse_BundledTrailingValueOption_TakesRemainderAsValue()
+        {
+            // For "-Dkey=val": prototype "D=" takes a value, ParseBundledValue
+            // hands it the entire remainder ("key=val") which the 2-value
+            // option splits on '=' / ':' default separators.
+            string? capturedKey = null;
+            string? capturedValue = null;
+            var set = new OptionSet
+            {
+                { "D=", (k, v) => { capturedKey = k; capturedValue = v; } },
+            };
+
+            set.Parse(new[] { "-Dkey=val" });
+
+            Assert.That(capturedKey, Is.EqualTo("key"));
+            Assert.That(capturedValue, Is.EqualTo("val"));
+        }
+
+        [Test]
+        public void Parse_BundlingNotAttemptedForDoubleDashPrefix()
+        {
+            // Critical contract: "--abc" looks for an option literally named
+            // "abc", it does NOT decompose into -a -b -c. This is what lets
+            // long flag names coexist with bundling.
+            var set = new OptionSet
+            {
+                { "a", _ => Assert.Fail("a should not have fired for --abc") },
+                { "b", _ => Assert.Fail("b should not have fired for --abc") },
+                { "c", _ => Assert.Fail("c should not have fired for --abc") },
+            };
+
+            var unprocessed = set.Parse(new[] { "--abc" });
+
+            Assert.That(unprocessed, Is.EqualTo(new[] { "--abc" }));
+        }
+
+        [Test]
+        public void Parse_BundlingNotAttemptedForSlashPrefix()
+        {
+            // Same contract for the Windows-style "/" prefix.
+            var set = new OptionSet { { "a", _ => Assert.Fail("a should not have fired for /abc") } };
+
+            var unprocessed = set.Parse(new[] { "/abc" });
+
+            Assert.That(unprocessed, Is.EqualTo(new[] { "/abc" }));
+        }
+
+        [Test]
+        public void Parse_BundleWithUnregisteredFollower_ThrowsOptionException()
+        {
+            var set = new OptionSet { { "a", _ => { } } };
+
+            // First char "a" is registered, second char "x" is not — message
+            // pins the diagnostic verbatim so callers can match on it.
+            var ex = Assert.Throws<OptionException>(() => set.Parse(new[] { "-ax" }))!;
+            Assert.That(ex.Message, Does.Contain("Cannot bundle unregistered option"));
+            Assert.That(ex.OptionName, Is.EqualTo("-x"));
+        }
+
+        [Test]
+        public void Parse_BundleWithUnregisteredLeader_ReturnsUnprocessedRatherThanThrowing()
+        {
+            // QUIRK: when the FIRST char of a bundle isn't registered, parsing
+            // gives up rather than throwing. The argument falls through to the
+            // unprocessed list. Pin this asymmetry.
+            var set = new OptionSet { { "a", _ => { } } };
+
+            var unprocessed = set.Parse(new[] { "-xa" });
+
+            Assert.That(unprocessed, Is.EqualTo(new[] { "-xa" }));
+        }
+
+        #endregion
+
+        #region Multi-value options
+
+        [Test]
+        public void Parse_MultiValueWithDefaultSeparators_SplitsOnEqualsAndColon()
+        {
+            // Prototype "p=" via OptionAction overload sets MaxValueCount=2
+            // and the default separators to [":", "="].
+            string? key = null;
+            string? value = null;
+            var set = new OptionSet { { "p=", (k, v) => { key = k; value = v; } } };
+
+            set.Parse(new[] { "--p=k=v" });
+
+            Assert.That(key, Is.EqualTo("k"));
+            Assert.That(value, Is.EqualTo("v"));
+        }
+
+        [Test]
+        public void Parse_MultiValueWithExplicitCommaSeparator_SplitsOnComma()
+        {
+            // Prototype "p=," count=2 — declared via Add(Option) since the
+            // higher-level Add overloads don't expose a separator-config knob.
+            string? key = null;
+            string? value = null;
+            var option = new TwoValueOption("p=,", (k, v) => { key = k; value = v; });
+            var set = new OptionSet { option };
+
+            set.Parse(new[] { "--p=alpha,beta" });
+
+            Assert.That(key, Is.EqualTo("alpha"));
+            Assert.That(value, Is.EqualTo("beta"));
+        }
+
+        [Test]
+        public void Parse_MultiValueWithEmptyBraceSeparator_RequiresDistinctArgvTokens()
+        {
+            // "{}" tells NDesk "do not split — values must be separate args".
+            string? key = null;
+            string? value = null;
+            var option = new TwoValueOption("p={}", (k, v) => { key = k; value = v; });
+            var set = new OptionSet { option };
+
+            set.Parse(new[] { "--p", "alpha", "beta" });
+
+            Assert.That(key, Is.EqualTo("alpha"));
+            Assert.That(value, Is.EqualTo("beta"));
+        }
+
+        [Test]
+        public void Parse_MultiValueWithTooManyValues_ThrowsOptionException()
+        {
+            var option = new TwoValueOption("p=,", (_, _) => { });
+            var set = new OptionSet { option };
+
+            // The localizer is invoked on the message — pin the unwrapped
+            // diagnostic so the modernised parser's message stays diff-able.
+            var ex = Assert.Throws<OptionException>(() => set.Parse(new[] { "--p=a,b,c" }))!;
+            Assert.That(ex.Message, Does.Contain("Found 3 option values when expecting 2"));
+        }
+
+        #endregion
+
+        #region "--" terminator
+
+        [Test]
+        public void Parse_DoubleDashStopsOptionProcessingAndPassesRemainderToUnprocessed()
+        {
+            string? captured = null;
+            var set = new OptionSet { { "name=", v => captured = v } };
+
+            var unprocessed = set.Parse(new[] { "--name=value", "--", "--other", "-x" });
+
+            Assert.That(captured, Is.EqualTo("value"));
+            Assert.That(unprocessed, Is.EqualTo(new[] { "--other", "-x" }));
+        }
+
+        [Test]
+        public void Parse_DoubleDashItselfIsNotIncludedInUnprocessed()
+        {
+            var set = new OptionSet();
+
+            var unprocessed = set.Parse(new[] { "--", "after" });
+
+            Assert.That(unprocessed, Is.EqualTo(new[] { "after" }));
+        }
+
+        #endregion
+
+        #region "<>" default handler
+
+        [Test]
+        public void Parse_DefaultHandlerCapturesEveryUnmatchedArgumentAndUnprocessedListIsEmpty()
+        {
+            var captured = new List<string>();
+            var set = new OptionSet
+            {
+                { "name=", _ => { } },
+                { "<>", v => captured.Add(v) },
+            };
+
+            var unprocessed = set.Parse(new[] { "first", "--name=v", "second", "third" });
+
+            Assert.That(captured, Is.EqualTo(new[] { "first", "second", "third" }));
+            Assert.That(unprocessed, Is.Empty);
+        }
+
+        [Test]
+        public void Parse_WithoutDefaultHandler_UnmatchedArgumentsAreReturnedInUnprocessedList()
+        {
+            string? captured = null;
+            var set = new OptionSet { { "name=", v => captured = v } };
+
+            var unprocessed = set.Parse(new[] { "first", "--name=v", "second" });
+
+            Assert.That(captured, Is.EqualTo("v"));
+            Assert.That(unprocessed, Is.EqualTo(new[] { "first", "second" }));
+        }
+
+        [Test]
+        public void Parse_DefaultHandlerAlsoReceivesArgumentsAfterDoubleDash()
+        {
+            // After "--", every remaining token routes through the same
+            // Unprocessed() helper — so a registered "<>" still picks them up.
+            var captured = new List<string>();
+            var set = new OptionSet
+            {
+                { "<>", v => captured.Add(v) },
+            };
+
+            set.Parse(new[] { "before", "--", "--after" });
+
+            Assert.That(captured, Is.EqualTo(new[] { "before", "--after" }));
+        }
+
+        #endregion
+
+        #region End-of-argv handling
+
+        [Test]
+        public void Parse_RequiredOptionAtEndWithoutValue_ThrowsWhenActionReadsTheValue()
+        {
+            // The pending-Option-at-end branch invokes regardless. The action
+            // (or the OptionValueCollection it accesses) is what throws when
+            // it reads c.OptionValues[0] for a Required option with no value.
+            var set = new OptionSet { { "name=", _ => { } } };
+
+            var ex = Assert.Throws<OptionException>(() => set.Parse(new[] { "--name" }))!;
+            Assert.That(ex.Message, Does.Contain("Missing required value for option"));
+            Assert.That(ex.OptionName, Is.EqualTo("--name"));
+        }
+
+        [Test]
+        public void Parse_OnEmptyArgs_ReturnsEmptyListAndInvokesNothing()
+        {
+            int invokeCount = 0;
+            var set = new OptionSet { { "name=", _ => invokeCount++ } };
+
+            var unprocessed = set.Parse(Array.Empty<string>());
+
+            Assert.That(unprocessed, Is.Empty);
+            Assert.That(invokeCount, Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region Localizer integration in error paths
+
+        [Test]
+        public void Parse_RoutesErrorMessageThroughCustomLocalizer()
+        {
+            // The "too many values" path passes its message through the
+            // configured localizer. Pin so the refactor doesn't accidentally
+            // bypass it — a translation hook breaking is non-obvious.
+            var set = new OptionSet(s => $"<<{s}>>");
+            var option = new TwoValueOption("p=,", (_, _) => { });
+            set.Add(option);
+
+            var ex = Assert.Throws<OptionException>(() => set.Parse(new[] { "--p=a,b,c" }))!;
+            Assert.That(ex.Message, Does.StartWith("<<"));
+            Assert.That(ex.Message, Does.EndWith(">>"));
+        }
+
+        #endregion
+
+        #region Realistic end-to-end smoke
+
+        [Test]
+        public void Parse_StampverStyleArgVector_FiresCorrectActionsAndCollectsPositionals()
+        {
+            // Approximates the prototype set wired up in Stampver.TryParseArguments.
+            // This isn't a substitute for the existing StampverTests integration
+            // suite — it pins that the full mix of option types coexists cleanly
+            // when handed to one OptionSet.
+            string? incrementPart = null;
+            int verboseHits = 0;
+            int dryRunHits = 0;
+            var set = new OptionSet
+            {
+                { "i=", v => incrementPart = v },
+                { "verbose", _ => verboseHits++ },
+                { "dryrun", _ => dryRunHits++ },
+            };
+
+            var positionals = set.Parse(new[] { "-i", "minor", "--verbose", "--dryrun", "*.cs" });
+
+            Assert.That(incrementPart, Is.EqualTo("minor"));
+            Assert.That(verboseHits, Is.EqualTo(1));
+            Assert.That(dryRunHits, Is.EqualTo(1));
+            Assert.That(positionals, Is.EqualTo(new[] { "*.cs" }));
+        }
+
+        #endregion
+
+        // Inline two-value Option subclass that lets us declare an explicit
+        // separator (the higher-level Add overloads don't expose this knob).
+        private sealed class TwoValueOption : Option
+        {
+            private readonly OptionAction<string, string> _action;
+
+            public TwoValueOption(string prototype, OptionAction<string, string> action)
+                : base(prototype, null!, 2)
+            {
+                _action = action;
+            }
+
+            protected override void OnParseComplete(OptionContext c)
+            {
+                _action(c.OptionValues[0], c.OptionValues[1]);
+            }
+        }
+    }
+}

--- a/src/stampver.tests/Options/OptionSetWriteDescriptionsTests.cs
+++ b/src/stampver.tests/Options/OptionSetWriteDescriptionsTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
-using NDesk.Options;
 using NUnit.Framework;
+using stampver.Options;
 
 namespace stampver.Tests.Options
 {
@@ -196,14 +196,18 @@ namespace stampver.Tests.Options
         }
 
         [Test]
-        public void WriteOptionDescriptions_StrayCloseBraceInDescription_Throws()
+        public void WriteOptionDescriptions_StrayCloseBraceInDescription_ThrowsFormatExceptionIdentifyingTheOption()
         {
-            // QUIRK: a single unbalanced "}" trips an InvalidOperationException
-            // from GetDescription. Pin so the refactor decides whether this
-            // panic-on-malformed-description behaviour stays.
+            // Phase 0 modernisation: an unbalanced "}" still aborts rendering,
+            // but the exception type is now FormatException (the BCL-standard
+            // choice for malformed input) and the message identifies which
+            // option's description is broken — much easier to diagnose than
+            // the original InvalidOperationException with a generic message.
             var set = new OptionSet { { "a", "broken } description", _ => { } } };
 
-            Assert.Throws<InvalidOperationException>(() => Render(set));
+            var ex = Assert.Throws<FormatException>(() => Render(set))!;
+            Assert.That(ex.Message, Does.Contain("'a'"),
+                "the message should identify the offending option by prototype.");
         }
 
         #endregion
@@ -251,13 +255,13 @@ namespace stampver.Tests.Options
         #region Localizer integration
 
         [Test]
-        public void WriteOptionDescriptions_LocalizerWrapsBracketAndEqualsTokensIndependentlyOfTheName()
+        public void WriteOptionDescriptions_LocalizerWrapsTheEntireValueTailAsOneFragment()
         {
-            // QUIRK worth knowing: WriteOptionPrototype runs the localizer on
-            // "[", "]", and "=VALUE" SEPARATELY but NOT on the option name
-            // itself. A localizer used as a poor-man's debug tracer would see
-            // each piece individually. Pin so the refactor either keeps the
-            // structure or documents a deliberate consolidation.
+            // Phase 0 modernisation: the value-tail "[=VALUE]" is built once
+            // and passed through the localizer as a single string, instead of
+            // the original NDesk approach of three separate localizer calls
+            // ("[", "=VALUE", "]"). A custom localizer can now translate the
+            // construct as a unit — which is what callers actually want.
             var localized = new OptionSet(s => $"<{s}>")
             {
                 { "name:", "wrapped", _ => { } },
@@ -265,12 +269,8 @@ namespace stampver.Tests.Options
 
             var output = Render(localized);
 
-            Assert.That(output, Does.Contain("<[>"),
-                "the '[' marker is wrapped by the localizer in isolation.");
-            Assert.That(output, Does.Contain("<=VALUE>"),
-                "the '=VALUE' fragment is wrapped by the localizer in isolation.");
-            Assert.That(output, Does.Contain("<]>"),
-                "the ']' marker is wrapped by the localizer in isolation.");
+            Assert.That(output, Does.Contain("<[=VALUE]>"),
+                "the bracketed value tail is wrapped by the localizer in one piece.");
             Assert.That(output, Does.Contain("--name"),
                 "the option name itself is NOT routed through the localizer.");
         }
@@ -281,9 +281,9 @@ namespace stampver.Tests.Options
         // separator-display path with explicit prototypes.
         private sealed class TwoValueOption : Option
         {
-            private readonly OptionAction<string, string> _action;
+            private readonly Action<string, string> _action;
 
-            public TwoValueOption(string prototype, OptionAction<string, string> action, string description)
+            public TwoValueOption(string prototype, Action<string, string> action, string description)
                 : base(prototype, description, 2)
             {
                 _action = action;

--- a/src/stampver.tests/Options/OptionSetWriteDescriptionsTests.cs
+++ b/src/stampver.tests/Options/OptionSetWriteDescriptionsTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.IO;
+using NDesk.Options;
+using NUnit.Framework;
+
+namespace stampver.Tests.Options
+{
+    // Pins WriteOptionDescriptions output line-by-line. Two implementation
+    // constants drive every layout decision and are reflected in the test
+    // expectations:
+    //   OptionWidth = 29  — column at which descriptions begin
+    //   line wrap   = 80 - OptionWidth - 2 = 49 chars per description line
+    // Continuation lines are indented OptionWidth+2 = 31 spaces.
+    [TestFixture]
+    internal sealed class OptionSetWriteDescriptionsTests
+    {
+        // Helper: write to a StringWriter with a fixed "\n" line ending so the
+        // expected strings are platform-stable (Environment.NewLine on Windows
+        // would otherwise be "\r\n").
+        private static string Render(OptionSet set)
+        {
+            var writer = new StringWriter { NewLine = "\n" };
+            set.WriteOptionDescriptions(writer);
+            return writer.ToString();
+        }
+
+        #region Layout — option-prototype rendering
+
+        [Test]
+        public void WriteOptionDescriptions_OnEmptyOptionSet_ProducesNoOutput()
+        {
+            var set = new OptionSet();
+
+            Assert.That(Render(set), Is.Empty);
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_BoolOptionWithSingleCharName_RendersWithTwoSpaceIndent()
+        {
+            var set = new OptionSet { { "a", "set the a flag", _ => { } } };
+
+            // Prototype "  -a" is 4 chars; pad with (29-4)=25 spaces; description follows.
+            Assert.That(Render(set), Is.EqualTo("  -a" + new string(' ', 25) + "set the a flag\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_BoolOptionWithLongName_RendersWithSixSpaceIndentAndDoubleDash()
+        {
+            var set = new OptionSet { { "verbose", "be loud", _ => { } } };
+
+            // "      --verbose" = 6 spaces + "--" + "verbose" = 15 chars. Pad (29-15)=14.
+            Assert.That(Render(set), Is.EqualTo("      --verbose" + new string(' ', 14) + "be loud\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_AliasedShortAndLongNames_RendersBothCommaSeparated()
+        {
+            var set = new OptionSet { { "h|help", "show help", _ => { } } };
+
+            // "  -h" (4) + ", --help" (8) = 12. Pad (29-12)=17.
+            Assert.That(Render(set), Is.EqualTo("  -h, --help" + new string(' ', 17) + "show help\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_OptionWithRequiredValue_AppendsEqualsValuePlaceholder()
+        {
+            var set = new OptionSet { { "name=", "give a name", _ => { } } };
+
+            // "      --name" (12) + "=VALUE" (6) = 18. Pad (29-18)=11.
+            Assert.That(Render(set), Is.EqualTo("      --name=VALUE" + new string(' ', 11) + "give a name\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_OptionWithOptionalValue_WrapsValuePlaceholderInBrackets()
+        {
+            var set = new OptionSet { { "name:", "optionally name", _ => { } } };
+
+            // "      --name" (12) + "[" + "=VALUE" + "]" = 20. Pad (29-20)=9.
+            Assert.That(Render(set), Is.EqualTo("      --name[=VALUE]" + new string(' ', 9) + "optionally name\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_DefaultHandlerEntryIsHiddenFromOutput()
+        {
+            // <> is excluded from the visible help by GetNextOptionIndex skipping
+            // any name == "<>". Pin so the refactor doesn't accidentally surface
+            // the default handler row.
+            var set = new OptionSet
+            {
+                { "<>", _ => { } },
+                { "a", "visible flag", _ => { } },
+            };
+
+            Assert.That(Render(set), Is.EqualTo("  -a" + new string(' ', 25) + "visible flag\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_PrototypeWiderThanOptionWidth_BreaksToNextLineAtFullColumnIndent()
+        {
+            // When the prototype is too wide to fit in 29 chars, WriteOptionDescriptions
+            // emits a newline and re-indents 29 spaces before the description.
+            var set = new OptionSet
+            {
+                { "name1|name2|name3|name4=", "stretchy", _ => { } },
+            };
+
+            // Prototype renders as "      --name1, --name2, --name3, --name4=VALUE"
+            //   "      --name1"     = 13
+            //   ", --name2"         = + 9  → 22
+            //   ", --name3"         = + 9  → 31  (already past 29 here)
+            //   ", --name4"         = + 9  → 40
+            //   "=VALUE"            = + 6  → 46
+            // Then a newline + 29 spaces + description.
+            const string expected = "      --name1, --name2, --name3, --name4=VALUE\n"
+                                  + "                             stretchy\n";
+            Assert.That(Render(set), Is.EqualTo(expected));
+        }
+
+        #endregion
+
+        #region Multi-value layout
+
+        [Test]
+        public void WriteOptionDescriptions_MultiValueOptionUsesFirstSeparatorBetweenPlaceholders()
+        {
+            // Prototype "p=" with the OptionAction overload sets MaxValueCount=2
+            // and the default separators to [":", "="]. The display picks
+            // ValueSeparators[0], so the colon shows up between placeholders.
+            var set = new OptionSet
+            {
+                { "p=", "two-value", (_, _) => { } },
+            };
+
+            // Single-char first name → short form "  -p" (4 chars), not "      --p".
+            // 4 + "=VALUE1" (7) + ":VALUE2" (7) = 18. Pad (29-18)=11.
+            Assert.That(Render(set), Is.EqualTo("  -p=VALUE1:VALUE2" + new string(' ', 11) + "two-value\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_MultiValueOptionWithEmptyBraceSeparatorRendersWithSpace()
+        {
+            // Prototype "p={}" disables value splitting (ValueSeparators == null)
+            // — the display falls back to a single space between placeholders.
+            var option = new TwoValueOption("p={}", (_, _) => { }, "two-with-space");
+            var set = new OptionSet { option };
+
+            // "  -p" (4) + "=VALUE1" (7) + " VALUE2" (7) = 18. Pad (29-18)=11.
+            Assert.That(Render(set), Is.EqualTo("  -p=VALUE1 VALUE2" + new string(' ', 11) + "two-with-space\n"));
+        }
+
+        #endregion
+
+        #region Description-driven argument naming
+
+        [Test]
+        public void WriteOptionDescriptions_BraceTokenInDescriptionRenamesValuePlaceholder()
+        {
+            var set = new OptionSet
+            {
+                { "name=", "Specify the {NAME}.", _ => { } },
+            };
+
+            // GetArgumentName extracts "NAME" from {NAME}; GetDescription strips
+            // the braces in the rendered description text. The argument name is
+            // also routed through the localizer (default identity) before display.
+            // "      --name=NAME" = 17. Pad (29-17)=12.
+            Assert.That(Render(set), Is.EqualTo("      --name=NAME" + new string(' ', 12) + "Specify the NAME.\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_IndexedBraceTokensRenameEachValuePlaceholder()
+        {
+            // Indexed form {0:KEY}/{1:VALUE} for multi-value options. The rendered
+            // description shows them with the colon stripped (just "KEY"/"VALUE").
+            var set = new OptionSet
+            {
+                { "p=", "Map {0:KEY} to {1:VALUE}.", (_, _) => { } },
+            };
+
+            // "  -p" (4) + "=KEY" (4) + ":VALUE" (6) = 14. Pad (29-14)=15.
+            const string expected = "  -p=KEY:VALUE" + "               Map KEY to VALUE.\n";
+            Assert.That(Render(set), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_DoubleOpenBraceInDescriptionEscapesToLiteralOpenBrace()
+        {
+            // {{ → literal { ; the placeholder still defaults to VALUE since no
+            // bare {NAME} pattern matches.
+            var set = new OptionSet
+            {
+                { "a", "Use {{ and }} for grouping.", _ => { } },
+            };
+
+            Assert.That(Render(set), Is.EqualTo("  -a" + new string(' ', 25) + "Use { and } for grouping.\n"));
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_StrayCloseBraceInDescription_Throws()
+        {
+            // QUIRK: a single unbalanced "}" trips an InvalidOperationException
+            // from GetDescription. Pin so the refactor decides whether this
+            // panic-on-malformed-description behaviour stays.
+            var set = new OptionSet { { "a", "broken } description", _ => { } } };
+
+            Assert.Throws<InvalidOperationException>(() => Render(set));
+        }
+
+        #endregion
+
+        #region Description wrapping
+
+        [Test]
+        public void WriteOptionDescriptions_DescriptionLongerThan49Chars_WrapsOntoContinuationLineWithDeepIndent()
+        {
+            // GetLines wraps at OptionWidth columns of remaining width — i.e.
+            // 80 - 29 - 2 = 49 chars per description line. Continuation lines
+            // are indented OptionWidth + 2 = 31 spaces.
+            var set = new OptionSet
+            {
+                { "a", "alpha bravo charlie delta echo foxtrot golf hotel india juliet", _ => { } },
+            };
+
+            var output = Render(set);
+
+            // Pin structural properties rather than the precise wrap point —
+            // GetLineEnd's choice of break char depends on input, but the
+            // continuation-line indent is invariant.
+            Assert.That(output, Does.Contain("\n" + new string(' ', 31)),
+                "continuation line should be indented 31 spaces.");
+            Assert.That(output.Split('\n').Length, Is.GreaterThan(2),
+                "long description should produce more than one rendered line.");
+        }
+
+        [Test]
+        public void WriteOptionDescriptions_NewlineInDescription_ForcesABreakBetweenLines()
+        {
+            // GetLineEnd treats '\n' as a hard break.
+            var set = new OptionSet
+            {
+                { "a", "first line\nsecond line", _ => { } },
+            };
+
+            const string expected = "  -a" + "                         first line\n"
+                                  + "                               second line\n";
+            Assert.That(Render(set), Is.EqualTo(expected));
+        }
+
+        #endregion
+
+        #region Localizer integration
+
+        [Test]
+        public void WriteOptionDescriptions_LocalizerWrapsBracketAndEqualsTokensIndependentlyOfTheName()
+        {
+            // QUIRK worth knowing: WriteOptionPrototype runs the localizer on
+            // "[", "]", and "=VALUE" SEPARATELY but NOT on the option name
+            // itself. A localizer used as a poor-man's debug tracer would see
+            // each piece individually. Pin so the refactor either keeps the
+            // structure or documents a deliberate consolidation.
+            var localized = new OptionSet(s => $"<{s}>")
+            {
+                { "name:", "wrapped", _ => { } },
+            };
+
+            var output = Render(localized);
+
+            Assert.That(output, Does.Contain("<[>"),
+                "the '[' marker is wrapped by the localizer in isolation.");
+            Assert.That(output, Does.Contain("<=VALUE>"),
+                "the '=VALUE' fragment is wrapped by the localizer in isolation.");
+            Assert.That(output, Does.Contain("<]>"),
+                "the ']' marker is wrapped by the localizer in isolation.");
+            Assert.That(output, Does.Contain("--name"),
+                "the option name itself is NOT routed through the localizer.");
+        }
+
+        #endregion
+
+        // Inline two-value Option subclass that lets us test the multi-value
+        // separator-display path with explicit prototypes.
+        private sealed class TwoValueOption : Option
+        {
+            private readonly OptionAction<string, string> _action;
+
+            public TwoValueOption(string prototype, OptionAction<string, string> action, string description)
+                : base(prototype, description, 2)
+            {
+                _action = action;
+            }
+
+            protected override void OnParseComplete(OptionContext c)
+            {
+                _action(c.OptionValues[0], c.OptionValues[1]);
+            }
+        }
+    }
+}

--- a/src/stampver.tests/Options/OptionValueCollectionTests.cs
+++ b/src/stampver.tests/Options/OptionValueCollectionTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NDesk.Options;
+using NUnit.Framework;
+
+namespace stampver.Tests.Options
+{
+    // Pins the observable behaviour of NDesk.Options.OptionValueCollection.
+    // The constructor is internal, so every test reaches the collection via
+    // OptionContext.OptionValues — this is the same path the parser uses.
+    [TestFixture]
+    internal sealed class OptionValueCollectionTests
+    {
+        private static OptionContext NewContext()
+        {
+            return new OptionContext(new OptionSet());
+        }
+
+        private static (OptionContext context, OptionValueCollection values) WithBoundOption(
+            string prototype = "name=", string optionName = "--name")
+        {
+            var set = new OptionSet { { prototype, _ => { } } };
+            var context = new OptionContext(set) { Option = set.First(), OptionName = optionName };
+            return (context, context.OptionValues);
+        }
+
+        #region Empty-state contract
+
+        [Test]
+        public void NewlyCreatedCollection_IsEmptyAndMutable()
+        {
+            var values = NewContext().OptionValues;
+
+            Assert.That(values.Count, Is.EqualTo(0));
+            Assert.That(values.IsReadOnly, Is.False);
+        }
+
+        [Test]
+        public void NewlyCreatedCollection_AsIList_IsNotFixedSize()
+        {
+            // Pinning the IList legacy face — IsFixedSize is one of the few
+            // members the typed IList<string> face doesn't expose.
+            IList values = NewContext().OptionValues;
+
+            Assert.That(values.IsFixedSize, Is.False);
+        }
+
+        #endregion
+
+        #region Mutation API
+
+        [Test]
+        public void Add_AppendsItemAndIncrementsCount()
+        {
+            var values = NewContext().OptionValues;
+
+            values.Add("first");
+            values.Add("second");
+
+            Assert.That(values.Count, Is.EqualTo(2));
+            Assert.That(values.IndexOf("first"), Is.EqualTo(0));
+            Assert.That(values.IndexOf("second"), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Add_AcceptsNull()
+        {
+            // The parser explicitly stores null when an optional value is absent
+            // (see ParseBool: "string v = n[n.Length-1] == '+' ? option : null").
+            // Refactor must keep null-tolerance.
+            var values = NewContext().OptionValues;
+
+            values.Add(null!);
+
+            Assert.That(values.Count, Is.EqualTo(1));
+            Assert.That(values.Contains(null!), Is.True);
+        }
+
+        [Test]
+        public void Clear_RemovesAllItems()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+            values.Add("b");
+
+            values.Clear();
+
+            Assert.That(values.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Remove_ReturnsTrueWhenItemFoundAndFalseOtherwise()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+
+            Assert.That(values.Remove("a"), Is.True);
+            Assert.That(values.Remove("a"), Is.False);
+            Assert.That(values.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Insert_PutsItemAtSpecifiedIndex()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+            values.Add("c");
+
+            values.Insert(1, "b");
+
+            Assert.That(values.ToArray(), Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        [Test]
+        public void RemoveAt_RemovesItemAtSpecifiedIndex()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+            values.Add("b");
+            values.Add("c");
+
+            values.RemoveAt(1);
+
+            Assert.That(values.ToArray(), Is.EqualTo(new[] { "a", "c" }));
+        }
+
+        [Test]
+        public void Contains_ReturnsTrueOnlyForPreviouslyAddedItems()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("present");
+
+            Assert.That(values.Contains("present"), Is.True);
+            Assert.That(values.Contains("absent"), Is.False);
+        }
+
+        [Test]
+        public void CopyTo_CopiesAllValuesIntoTargetArrayAtSpecifiedOffset()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+            values.Add("b");
+            var target = new string[4];
+
+            values.CopyTo(target, 1);
+
+            Assert.That(target, Is.EqualTo(new[] { null, "a", "b", null }));
+        }
+
+        #endregion
+
+        #region Enumeration
+
+        [Test]
+        public void GetEnumerator_YieldsItemsInInsertionOrder()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("one");
+            values.Add("two");
+            values.Add("three");
+
+            var collected = new List<string>();
+            foreach (var v in values)
+            {
+                collected.Add(v);
+            }
+
+            Assert.That(collected, Is.EqualTo(new[] { "one", "two", "three" }));
+        }
+
+        #endregion
+
+        #region Indexer — getter triggers AssertValid
+
+        [Test]
+        public void IndexerGetter_WithoutBoundOption_ThrowsInvalidOperationException()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("ignored");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => _ = values[0])!;
+            Assert.That(ex.Message, Is.EqualTo("OptionContext.Option is null."));
+        }
+
+        [Test]
+        public void IndexerGetter_BeyondMaxValueCount_ThrowsArgumentOutOfRangeException()
+        {
+            var (_, values) = WithBoundOption("name=");
+            values.Add("v");
+
+            // MaxValueCount for "name=" is 1, so index 1 trips the guard before
+            // the values-list bounds check.
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = values[1]);
+        }
+
+        [Test]
+        public void IndexerGetter_WithRequiredTypeAndMissingValue_ThrowsOptionException()
+        {
+            var (_, values) = WithBoundOption("name=", "--name");
+
+            var ex = Assert.Throws<OptionException>(() => _ = values[0])!;
+            Assert.That(ex.OptionName, Is.EqualTo("--name"));
+            Assert.That(ex.Message, Is.EqualTo("Missing required value for option '--name'."));
+        }
+
+        [Test]
+        public void IndexerGetter_WithOptionalTypeAndMissingValue_ReturnsNull()
+        {
+            // Optional-type options don't trip the OptionException path; the
+            // documented behaviour is "return null past the end of values".
+            var (_, values) = WithBoundOption("name:", "--name");
+
+            Assert.That(values[0], Is.Null);
+        }
+
+        [Test]
+        public void IndexerGetter_WithValidIndexBelowCount_ReturnsStoredValue()
+        {
+            var (_, values) = WithBoundOption("name=");
+            values.Add("hello");
+
+            Assert.That(values[0], Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public void IndexerSetter_DoesNotGoThroughAssertValid()
+        {
+            // Quirk: the setter delegates straight to the underlying List<string>
+            // and skips AssertValid entirely. Pinning so the refactor decides
+            // explicitly whether to keep this asymmetry.
+            var values = NewContext().OptionValues;
+            values.Add("original");
+
+            values[0] = "replaced";
+
+            // Reading back via ToArray bypasses the AssertValid path on get.
+            Assert.That(values.ToArray()[0], Is.EqualTo("replaced"));
+        }
+
+        #endregion
+
+        #region Snapshot helpers
+
+        [Test]
+        public void ToList_ReturnsACopyThatIsDecoupledFromTheCollection()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+            values.Add("b");
+
+            var snapshot = values.ToList();
+            snapshot.Add("c");
+
+            Assert.That(snapshot, Is.EqualTo(new[] { "a", "b", "c" }));
+            Assert.That(values.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void ToArray_ReturnsACopyThatIsDecoupledFromTheCollection()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("a");
+            values.Add("b");
+
+            var snapshot = values.ToArray();
+            snapshot[0] = "mutated";
+
+            Assert.That(values.ToArray()[0], Is.EqualTo("a"));
+        }
+
+        [Test]
+        public void ToString_JoinsValuesWithCommaSpace()
+        {
+            var values = NewContext().OptionValues;
+            values.Add("one");
+            values.Add("two");
+            values.Add("three");
+
+            Assert.That(values.ToString(), Is.EqualTo("one, two, three"));
+        }
+
+        [Test]
+        public void ToString_OnEmptyCollection_ReturnsEmptyString()
+        {
+            var values = NewContext().OptionValues;
+
+            Assert.That(values.ToString(), Is.EqualTo(string.Empty));
+        }
+
+        #endregion
+    }
+}

--- a/src/stampver.tests/Options/OptionValueCollectionTests.cs
+++ b/src/stampver.tests/Options/OptionValueCollectionTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using NDesk.Options;
+using stampver.Options;
 using NUnit.Framework;
 
 namespace stampver.Tests.Options

--- a/src/stampver/Options.cs
+++ b/src/stampver/Options.cs
@@ -1,1101 +1,1071 @@
-//
-// Options.cs
-//
-// Authors:
-//  Jonathan Pryor <jpryor@novell.com>
-//
-// Copyright (C) 2008 Novell (http://www.novell.com)
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-
-// Compile With:
-//   gmcs -debug+ -r:System.Core Options.cs -o:NDesk.Options.dll
-//   gmcs -debug+ -d:LINQ -r:System.Core Options.cs -o:NDesk.Options.dll
-//
-// The LINQ version just changes the implementation of
-// OptionSet.Parse(IEnumerable<string>), and confers no semantic changes.
-
-//
-// A Getopt::Long-inspired option parsing library for C#.
-//
-// NDesk.Options.OptionSet is built upon a key/value table, where the
-// key is a option format string and the value is a delegate that is 
-// invoked when the format string is matched.
-//
-// Option format strings:
-//  Regex-like BNF Grammar: 
-//    name: .+
-//    type: [=:]
-//    sep: ( [^{}]+ | '{' .+ '}' )?
-//    aliases: ( name type sep ) ( '|' name type sep )*
-// 
-// Each '|'-delimited name is an alias for the associated action.  If the
-// format string ends in a '=', it has a required value.  If the format
-// string ends in a ':', it has an optional value.  If neither '=' or ':'
-// is present, no value is supported.  `=' or `:' need only be defined on one
-// alias, but if they are provided on more than one they must be consistent.
-//
-// Each alias portion may also end with a "key/value separator", which is used
-// to split option values if the option accepts > 1 value.  If not specified,
-// it defaults to '=' and ':'.  If specified, it can be any character except
-// '{' and '}' OR the *string* between '{' and '}'.  If no separator should be
-// used (i.e. the separate values should be distinct arguments), then "{}"
-// should be used as the separator.
-//
-// Options are extracted either from the current option by looking for
-// the option name followed by an '=' or ':', or is taken from the
-// following option IFF:
-//  - The current option does not contain a '=' or a ':'
-//  - The current option requires a value (i.e. not a Option type of ':')
-//
-// The `name' used in the option format string does NOT include any leading
-// option indicator, such as '-', '--', or '/'.  All three of these are
-// permitted/required on any named option.
-//
-// Option bundling is permitted so long as:
-//   - '-' is used to start the option group
-//   - all of the bundled options are a single character
-//   - at most one of the bundled options accepts a value, and the value
-//     provided starts from the next character to the end of the string.
-//
-// This allows specifying '-a -b -c' as '-abc', and specifying '-D name=value'
-// as '-Dname=value'.
-//
-// Option processing is disabled by specifying "--".  All options after "--"
-// are returned by OptionSet.Parse() unchanged and unprocessed.
-//
-// Unprocessed options are returned from OptionSet.Parse().
-//
-// Examples:
-//  int verbose = 0;
-//  OptionSet p = new OptionSet ()
-//    .Add ("v", v => ++verbose)
-//    .Add ("name=|value=", v => Console.WriteLine (v));
-//  p.Parse (new string[]{"-v", "--v", "/v", "-name=A", "/name", "B", "extra"});
-//
-// The above would parse the argument string array, and would invoke the
-// lambda expression three times, setting `verbose' to 3 when complete.  
-// It would also print out "A" and "B" to standard output.
-// The returned array would contain the string "extra".
-//
-// C# 3.0 collection initializers are supported and encouraged:
-//  var p = new OptionSet () {
-//    { "h|?|help", v => ShowHelp () },
-//  };
-//
-// System.ComponentModel.TypeConverter is also supported, allowing the use of
-// custom data types in the callback type; TypeConverter.ConvertFromString()
-// is used to convert the value option to an instance of the specified
-// type:
-//
-//  var p = new OptionSet () {
-//    { "foo=", (Foo f) => Console.WriteLine (f.ToString ()) },
-//  };
-//
-// Random other tidbits:
-//  - Boolean options (those w/o '=' or ':' in the option format string)
-//    are explicitly enabled if they are followed with '+', and explicitly
-//    disabled if they are followed with '-':
-//      string a = null;
-//      var p = new OptionSet () {
-//        { "a", s => a = s },
-//      };
-//      p.Parse (new string[]{"-a"});   // sets v != null
-//      p.Parse (new string[]{"-a+"});  // sets v != null
-//      p.Parse (new string[]{"-a-"});  // sets v == null
-//
+// Originally derived from NDesk.Options by Jonathan Pryor (Novell, MIT, 2008).
+// Substantially rewritten 2026 to target modern C#, drop legacy interop, and
+// fix several observable bugs and quirks pinned by the unit-test suite.
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
-// ReSharper disable CheckNamespace
 
-#if LINQ
-using System.Linq;
-#endif
+namespace stampver.Options;
 
-#if TEST
-using NDesk.Options;
-#endif
-
-namespace NDesk.Options {
-
-	public class OptionValueCollection : IList, IList<string> {
-
-		List<string> values = new List<string> ();
-		OptionContext c;
-
-		internal OptionValueCollection (OptionContext c)
-		{
-			this.c = c;
-		}
-
-		#region ICollection
-		void ICollection.CopyTo (Array array, int index)  {(values as ICollection).CopyTo (array, index);}
-		bool ICollection.IsSynchronized                   {get {return (values as ICollection).IsSynchronized;}}
-		object ICollection.SyncRoot                       {get {return (values as ICollection).SyncRoot;}}
-		#endregion
-
-		#region ICollection<T>
-		public void Add (string item)                       {values.Add (item);}
-		public void Clear ()                                {values.Clear ();}
-		public bool Contains (string item)                  {return values.Contains (item);}
-		public void CopyTo (string[] array, int arrayIndex) {values.CopyTo (array, arrayIndex);}
-		public bool Remove (string item)                    {return values.Remove (item);}
-		public int Count                                    {get {return values.Count;}}
-		public bool IsReadOnly                              {get {return false;}}
-		#endregion
-
-		#region IEnumerable
-		IEnumerator IEnumerable.GetEnumerator () {return values.GetEnumerator ();}
-		#endregion
-
-		#region IEnumerable<T>
-		public IEnumerator<string> GetEnumerator () {return values.GetEnumerator ();}
-		#endregion
-
-		#region IList
-		int IList.Add (object value)                {return (values as IList).Add (value);}
-		bool IList.Contains (object value)          {return (values as IList).Contains (value);}
-		int IList.IndexOf (object value)            {return (values as IList).IndexOf (value);}
-		void IList.Insert (int index, object value) {(values as IList).Insert (index, value);}
-		void IList.Remove (object value)            {(values as IList).Remove (value);}
-		void IList.RemoveAt (int index)             {(values as IList).RemoveAt (index);}
-		bool IList.IsFixedSize                      {get {return false;}}
-		object IList.this [int index]               {get {return this [index];} set {(values as IList)[index] = value;}}
-		#endregion
-
-		#region IList<T>
-		public int IndexOf (string item)            {return values.IndexOf (item);}
-		public void Insert (int index, string item) {values.Insert (index, item);}
-		public void RemoveAt (int index)            {values.RemoveAt (index);}
-
-		private void AssertValid (int index)
-		{
-			if (c.Option == null)
-				throw new InvalidOperationException ("OptionContext.Option is null.");
-			if (index >= c.Option.MaxValueCount)
-				throw new ArgumentOutOfRangeException ("index");
-			if (c.Option.OptionValueType == OptionValueType.Required &&
-					index >= values.Count)
-				throw new OptionException (string.Format (
-							c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName), 
-						c.OptionName);
-		}
-
-		public string this [int index] {
-			get {
-				AssertValid (index);
-				return index >= values.Count ? null : values [index];
-			}
-			set {
-				values [index] = value;
-			}
-		}
-		#endregion
-
-		public List<string> ToList ()
-		{
-			return new List<string> (values);
-		}
-
-		public string[] ToArray ()
-		{
-			return values.ToArray ();
-		}
-
-		public override string ToString ()
-		{
-			return string.Join (", ", values.ToArray ());
-		}
-	}
-
-	public class OptionContext {
-		private Option                option;
-		private string                name;
-		private int                   index;
-		private OptionSet             set;
-		private OptionValueCollection c;
-
-		public OptionContext (OptionSet set)
-		{
-			this.set = set;
-			this.c   = new OptionValueCollection (this);
-		}
-
-		public Option Option {
-			get {return option;}
-			set {option = value;}
-		}
-
-		public string OptionName { 
-			get {return name;}
-			set {name = value;}
-		}
-
-		public int OptionIndex {
-			get {return index;}
-			set {index = value;}
-		}
-
-		public OptionSet OptionSet {
-			get {return set;}
-		}
-
-		public OptionValueCollection OptionValues {
-			get {return c;}
-		}
-	}
-
-	public enum OptionValueType {
-		None, 
-		Optional,
-		Required,
-	}
-
-	public abstract class Option {
-		string prototype, description;
-		string[] names;
-		OptionValueType type;
-		int count;
-		string[] separators;
-
-		protected Option (string prototype, string description)
-			: this (prototype, description, 1)
-		{
-		}
-
-		protected Option (string prototype, string description, int maxValueCount)
-		{
-			if (prototype == null)
-				throw new ArgumentNullException ("prototype");
-			if (prototype.Length == 0)
-				throw new ArgumentException ("Cannot be the empty string.", "prototype");
-			if (maxValueCount < 0)
-				throw new ArgumentOutOfRangeException ("maxValueCount");
-
-			this.prototype   = prototype;
-			this.names       = prototype.Split ('|');
-			this.description = description;
-			this.count       = maxValueCount;
-			this.type        = ParsePrototype ();
-
-			if (this.count == 0 && type != OptionValueType.None)
-				throw new ArgumentException (
-						"Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
-							"OptionValueType.Optional.",
-						"maxValueCount");
-			if (this.type == OptionValueType.None && maxValueCount > 1)
-				throw new ArgumentException (
-						string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
-						"maxValueCount");
-			if (Array.IndexOf (names, "<>") >= 0 && 
-					((names.Length == 1 && this.type != OptionValueType.None) ||
-					 (names.Length > 1 && this.MaxValueCount > 1)))
-				throw new ArgumentException (
-						"The default option handler '<>' cannot require values.",
-						"prototype");
-		}
-
-		public string           Prototype       {get {return prototype;}}
-		public string           Description     {get {return description;}}
-		public OptionValueType  OptionValueType {get {return type;}}
-		public int              MaxValueCount   {get {return count;}}
-
-		public string[] GetNames ()
-		{
-			return (string[]) names.Clone ();
-		}
-
-		public string[] GetValueSeparators ()
-		{
-			if (separators == null)
-				return new string [0];
-			return (string[]) separators.Clone ();
-		}
-
-		protected static T Parse<T> (string value, OptionContext c)
-		{
-			TypeConverter conv = TypeDescriptor.GetConverter (typeof (T));
-			T t = default (T);
-			try {
-				if (value != null)
-					t = (T) conv.ConvertFromString (value);
-			}
-			catch (Exception e) {
-				throw new OptionException (
-						string.Format (
-							c.OptionSet.MessageLocalizer ("Could not convert string `{0}' to type {1} for option `{2}'."),
-							value, typeof (T).Name, c.OptionName),
-						c.OptionName, e);
-			}
-			return t;
-		}
-
-		internal string[] Names           {get {return names;}}
-		internal string[] ValueSeparators {get {return separators;}}
-
-		static readonly char[] NameTerminator = new char[]{'=', ':'};
-
-		private OptionValueType ParsePrototype ()
-		{
-			char type = '\0';
-			List<string> seps = new List<string> ();
-			for (int i = 0; i < names.Length; ++i) {
-				string name = names [i];
-				if (name.Length == 0)
-					throw new ArgumentException ("Empty option names are not supported.", "prototype");
-
-				int end = name.IndexOfAny (NameTerminator);
-				if (end == -1)
-					continue;
-				names [i] = name.Substring (0, end);
-				if (type == '\0' || type == name [end])
-					type = name [end];
-				else 
-					throw new ArgumentException (
-							string.Format ("Conflicting option types: '{0}' vs. '{1}'.", type, name [end]),
-							"prototype");
-				AddSeparators (name, end, seps);
-			}
-
-			if (type == '\0')
-				return OptionValueType.None;
-
-			if (count <= 1 && seps.Count != 0)
-				throw new ArgumentException (
-						string.Format ("Cannot provide key/value separators for Options taking {0} value(s).", count),
-						"prototype");
-			if (count > 1) {
-				if (seps.Count == 0)
-					this.separators = new string[]{":", "="};
-				else if (seps.Count == 1 && seps [0].Length == 0)
-					this.separators = null;
-				else
-					this.separators = seps.ToArray ();
-			}
-
-			return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
-		}
-
-		private static void AddSeparators (string name, int end, ICollection<string> seps)
-		{
-			int start = -1;
-			for (int i = end+1; i < name.Length; ++i) {
-				switch (name [i]) {
-					case '{':
-						if (start != -1)
-							throw new ArgumentException (
-									string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
-									"prototype");
-						start = i+1;
-						break;
-					case '}':
-						if (start == -1)
-							throw new ArgumentException (
-									string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
-									"prototype");
-						seps.Add (name.Substring (start, i-start));
-						start = -1;
-						break;
-					default:
-						if (start == -1)
-							seps.Add (name [i].ToString ());
-						break;
-				}
-			}
-			if (start != -1)
-				throw new ArgumentException (
-						string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
-						"prototype");
-		}
-
-		public void Invoke (OptionContext c)
-		{
-			OnParseComplete (c);
-			c.OptionName  = null;
-			c.Option      = null;
-			c.OptionValues.Clear ();
-		}
-
-		protected abstract void OnParseComplete (OptionContext c);
-
-		public override string ToString ()
-		{
-			return Prototype;
-		}
-	}
-
-	[Serializable]
-	public class OptionException : Exception {
-		private string option;
-
-		public OptionException ()
-		{
-		}
-
-		public OptionException (string message, string optionName)
-			: base (message)
-		{
-			this.option = optionName;
-		}
-
-		public OptionException (string message, string optionName, Exception innerException)
-			: base (message, innerException)
-		{
-			this.option = optionName;
-		}
-
-		protected OptionException (SerializationInfo info, StreamingContext context)
-			: base (info, context)
-		{
-			this.option = info.GetString ("OptionName");
-		}
-
-		public string OptionName {
-			get {return this.option;}
-		}
-
-		public override void GetObjectData (SerializationInfo info, StreamingContext context)
-		{
-			base.GetObjectData (info, context);
-			info.AddValue ("OptionName", option);
-		}
-	}
-
-	public delegate void OptionAction<TKey, TValue> (TKey key, TValue value);
-
-	public class OptionSet : KeyedCollection<string, Option>
-	{
-		public OptionSet ()
-			: this (delegate (string f) {return f;})
-		{
-		}
-
-		public OptionSet (Converter<string, string> localizer)
-		{
-			this.localizer = localizer;
-		}
-
-		Converter<string, string> localizer;
-
-		public Converter<string, string> MessageLocalizer {
-			get {return localizer;}
-		}
-
-		protected override string GetKeyForItem (Option item)
-		{
-			if (item == null)
-				throw new ArgumentNullException ("option");
-			if (item.Names != null && item.Names.Length > 0)
-				return item.Names [0];
-			// This should never happen, as it's invalid for Option to be
-			// constructed w/o any names.
-			throw new InvalidOperationException ("Option has no names!");
-		}
-
-		[Obsolete ("Use KeyedCollection.this[string]")]
-		protected Option GetOptionForName (string option)
-		{
-			if (option == null)
-				throw new ArgumentNullException ("option");
-			try {
-				return base [option];
-			}
-			catch (KeyNotFoundException) {
-				return null;
-			}
-		}
-
-		protected override void InsertItem (int index, Option item)
-		{
-			base.InsertItem (index, item);
-			AddImpl (item);
-		}
-
-		protected override void RemoveItem (int index)
-		{
-			base.RemoveItem (index);
-			Option p = Items [index];
-			// KeyedCollection.RemoveItem() handles the 0th item
-			for (int i = 1; i < p.Names.Length; ++i) {
-				Dictionary.Remove (p.Names [i]);
-			}
-		}
-
-		protected override void SetItem (int index, Option item)
-		{
-			base.SetItem (index, item);
-			RemoveItem (index);
-			AddImpl (item);
-		}
-
-		private void AddImpl (Option option)
-		{
-			if (option == null)
-				throw new ArgumentNullException ("option");
-			List<string> added = new List<string> (option.Names.Length);
-			try {
-				// KeyedCollection.InsertItem/SetItem handle the 0th name.
-				for (int i = 1; i < option.Names.Length; ++i) {
-					Dictionary.Add (option.Names [i], option);
-					added.Add (option.Names [i]);
-				}
-			}
-			catch (Exception) {
-				foreach (string name in added)
-					Dictionary.Remove (name);
-				throw;
-			}
-		}
-
-		public new OptionSet Add (Option option)
-		{
-			base.Add (option);
-			return this;
-		}
-
-		sealed class ActionOption : Option {
-			Action<OptionValueCollection> action;
-
-			public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action)
-				: base (prototype, description, count)
-			{
-				if (action == null)
-					throw new ArgumentNullException ("action");
-				this.action = action;
-			}
-
-			protected override void OnParseComplete (OptionContext c)
-			{
-				action (c.OptionValues);
-			}
-		}
-
-		public OptionSet Add (string prototype, Action<string> action)
-		{
-			return Add (prototype, null, action);
-		}
-
-		public OptionSet Add (string prototype, string description, Action<string> action)
-		{
-			if (action == null)
-				throw new ArgumentNullException ("action");
-			Option p = new ActionOption (prototype, description, 1, 
-					delegate (OptionValueCollection v) { action (v [0]); });
-			base.Add (p);
-			return this;
-		}
-
-		public OptionSet Add (string prototype, OptionAction<string, string> action)
-		{
-			return Add (prototype, null, action);
-		}
-
-		public OptionSet Add (string prototype, string description, OptionAction<string, string> action)
-		{
-			if (action == null)
-				throw new ArgumentNullException ("action");
-			Option p = new ActionOption (prototype, description, 2, 
-					delegate (OptionValueCollection v) {action (v [0], v [1]);});
-			base.Add (p);
-			return this;
-		}
-
-		sealed class ActionOption<T> : Option {
-			Action<T> action;
-
-			public ActionOption (string prototype, string description, Action<T> action)
-				: base (prototype, description, 1)
-			{
-				if (action == null)
-					throw new ArgumentNullException ("action");
-				this.action = action;
-			}
-
-			protected override void OnParseComplete (OptionContext c)
-			{
-				action (Parse<T> (c.OptionValues [0], c));
-			}
-		}
-
-		sealed class ActionOption<TKey, TValue> : Option {
-			OptionAction<TKey, TValue> action;
-
-			public ActionOption (string prototype, string description, OptionAction<TKey, TValue> action)
-				: base (prototype, description, 2)
-			{
-				if (action == null)
-					throw new ArgumentNullException ("action");
-				this.action = action;
-			}
-
-			protected override void OnParseComplete (OptionContext c)
-			{
-				action (
-						Parse<TKey> (c.OptionValues [0], c),
-						Parse<TValue> (c.OptionValues [1], c));
-			}
-		}
-
-		public OptionSet Add<T> (string prototype, Action<T> action)
-		{
-			return Add (prototype, null, action);
-		}
-
-		public OptionSet Add<T> (string prototype, string description, Action<T> action)
-		{
-			return Add (new ActionOption<T> (prototype, description, action));
-		}
-
-		public OptionSet Add<TKey, TValue> (string prototype, OptionAction<TKey, TValue> action)
-		{
-			return Add (prototype, null, action);
-		}
-
-		public OptionSet Add<TKey, TValue> (string prototype, string description, OptionAction<TKey, TValue> action)
-		{
-			return Add (new ActionOption<TKey, TValue> (prototype, description, action));
-		}
-
-		protected virtual OptionContext CreateOptionContext ()
-		{
-			return new OptionContext (this);
-		}
-
-#if LINQ
-		public List<string> Parse (IEnumerable<string> arguments)
-		{
-			bool process = true;
-			OptionContext c = CreateOptionContext ();
-			c.OptionIndex = -1;
-			var def = GetOptionForName ("<>");
-			var unprocessed = 
-				from argument in arguments
-				where ++c.OptionIndex >= 0 && (process || def != null)
-					? process
-						? argument == "--" 
-							? (process = false)
-							: !Parse (argument, c)
-								? def != null 
-									? Unprocessed (null, def, c, argument) 
-									: true
-								: false
-						: def != null 
-							? Unprocessed (null, def, c, argument)
-							: true
-					: true
-				select argument;
-			List<string> r = unprocessed.ToList ();
-			if (c.Option != null)
-				c.Option.Invoke (c);
-			return r;
-		}
-#else
-		public List<string> Parse (IEnumerable<string> arguments)
-		{
-			OptionContext c = CreateOptionContext ();
-			c.OptionIndex = -1;
-			bool process = true;
-			List<string> unprocessed = new List<string> ();
-			Option def = Contains ("<>") ? this ["<>"] : null;
-			foreach (string argument in arguments) {
-				++c.OptionIndex;
-				if (argument == "--") {
-					process = false;
-					continue;
-				}
-				if (!process) {
-					Unprocessed (unprocessed, def, c, argument);
-					continue;
-				}
-				if (!Parse (argument, c))
-					Unprocessed (unprocessed, def, c, argument);
-			}
-			if (c.Option != null)
-				c.Option.Invoke (c);
-			return unprocessed;
-		}
-#endif
-
-		private static bool Unprocessed (ICollection<string> extra, Option def, OptionContext c, string argument)
-		{
-			if (def == null) {
-				extra.Add (argument);
-				return false;
-			}
-			c.OptionValues.Add (argument);
-			c.Option = def;
-			c.Option.Invoke (c);
-			return false;
-		}
-
-		private readonly Regex ValueOption = new Regex (
-			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
-
-		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
-		{
-			if (argument == null)
-				throw new ArgumentNullException ("argument");
-
-			flag = name = sep = value = null;
-			Match m = ValueOption.Match (argument);
-			if (!m.Success) {
-				return false;
-			}
-			flag  = m.Groups ["flag"].Value;
-			name  = m.Groups ["name"].Value;
-			if (m.Groups ["sep"].Success && m.Groups ["value"].Success) {
-				sep   = m.Groups ["sep"].Value;
-				value = m.Groups ["value"].Value;
-			}
-			return true;
-		}
-
-		protected virtual bool Parse (string argument, OptionContext c)
-		{
-			if (c.Option != null) {
-				ParseValue (argument, c);
-				return true;
-			}
-
-			string f, n, s, v;
-			if (!GetOptionParts (argument, out f, out n, out s, out v))
-				return false;
-
-			Option p;
-			if (Contains (n)) {
-				p = this [n];
-				c.OptionName = f + n;
-				c.Option     = p;
-				switch (p.OptionValueType) {
-					case OptionValueType.None:
-						c.OptionValues.Add (n);
-						c.Option.Invoke (c);
-						break;
-					case OptionValueType.Optional:
-					case OptionValueType.Required: 
-						ParseValue (v, c);
-						break;
-				}
-				return true;
-			}
-			// no match; is it a bool option?
-			if (ParseBool (argument, n, c))
-				return true;
-			// is it a bundled option?
-			if (ParseBundledValue (f, string.Concat (n + s + v), c))
-				return true;
-
-			return false;
-		}
-
-		private void ParseValue (string option, OptionContext c)
-		{
-			if (option != null)
-				foreach (string o in c.Option.ValueSeparators != null 
-						? option.Split (c.Option.ValueSeparators, StringSplitOptions.None)
-						: new string[]{option}) {
-					c.OptionValues.Add (o);
-				}
-			if (c.OptionValues.Count == c.Option.MaxValueCount || 
-					c.Option.OptionValueType == OptionValueType.Optional)
-				c.Option.Invoke (c);
-			else if (c.OptionValues.Count > c.Option.MaxValueCount) {
-				throw new OptionException (localizer (string.Format (
-								"Error: Found {0} option values when expecting {1}.", 
-								c.OptionValues.Count, c.Option.MaxValueCount)),
-						c.OptionName);
-			}
-		}
-
-		private bool ParseBool (string option, string n, OptionContext c)
-		{
-			Option p;
-			string rn;
-			if (n.Length >= 1 && (n [n.Length-1] == '+' || n [n.Length-1] == '-') &&
-					Contains ((rn = n.Substring (0, n.Length-1)))) {
-				p = this [rn];
-				string v = n [n.Length-1] == '+' ? option : null;
-				c.OptionName  = option;
-				c.Option      = p;
-				c.OptionValues.Add (v);
-				p.Invoke (c);
-				return true;
-			}
-			return false;
-		}
-
-		private bool ParseBundledValue (string f, string n, OptionContext c)
-		{
-			if (f != "-")
-				return false;
-			for (int i = 0; i < n.Length; ++i) {
-				Option p;
-				string opt = f + n [i].ToString ();
-				string rn = n [i].ToString ();
-				if (!Contains (rn)) {
-					if (i == 0)
-						return false;
-					throw new OptionException (string.Format (localizer (
-									"Cannot bundle unregistered option '{0}'."), opt), opt);
-				}
-				p = this [rn];
-				switch (p.OptionValueType) {
-					case OptionValueType.None:
-						Invoke (c, opt, n, p);
-						break;
-					case OptionValueType.Optional:
-					case OptionValueType.Required: {
-						string v     = n.Substring (i+1);
-						c.Option     = p;
-						c.OptionName = opt;
-						ParseValue (v.Length != 0 ? v : null, c);
-						return true;
-					}
-					default:
-						throw new InvalidOperationException ("Unknown OptionValueType: " + p.OptionValueType);
-				}
-			}
-			return true;
-		}
-
-		private static void Invoke (OptionContext c, string name, string value, Option option)
-		{
-			c.OptionName  = name;
-			c.Option      = option;
-			c.OptionValues.Add (value);
-			option.Invoke (c);
-		}
-
-		private const int OptionWidth = 29;
-
-		public void WriteOptionDescriptions (TextWriter o)
-		{
-			foreach (Option p in this) {
-				int written = 0;
-				if (!WriteOptionPrototype (o, p, ref written))
-					continue;
-
-				if (written < OptionWidth)
-					o.Write (new string (' ', OptionWidth - written));
-				else {
-					o.WriteLine ();
-					o.Write (new string (' ', OptionWidth));
-				}
-
-				List<string> lines = GetLines (localizer (GetDescription (p.Description)));
-				o.WriteLine (lines [0]);
-				string prefix = new string (' ', OptionWidth+2);
-				for (int i = 1; i < lines.Count; ++i) {
-					o.Write (prefix);
-					o.WriteLine (lines [i]);
-				}
-			}
-		}
-
-		bool WriteOptionPrototype (TextWriter o, Option p, ref int written)
-		{
-			string[] names = p.Names;
-
-			int i = GetNextOptionIndex (names, 0);
-			if (i == names.Length)
-				return false;
-
-			if (names [i].Length == 1) {
-				Write (o, ref written, "  -");
-				Write (o, ref written, names [0]);
-			}
-			else {
-				Write (o, ref written, "      --");
-				Write (o, ref written, names [0]);
-			}
-
-			for ( i = GetNextOptionIndex (names, i+1); 
-					i < names.Length; i = GetNextOptionIndex (names, i+1)) {
-				Write (o, ref written, ", ");
-				Write (o, ref written, names [i].Length == 1 ? "-" : "--");
-				Write (o, ref written, names [i]);
-			}
-
-			if (p.OptionValueType == OptionValueType.Optional ||
-					p.OptionValueType == OptionValueType.Required) {
-				if (p.OptionValueType == OptionValueType.Optional) {
-					Write (o, ref written, localizer ("["));
-				}
-				Write (o, ref written, localizer ("=" + GetArgumentName (0, p.MaxValueCount, p.Description)));
-				string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0 
-					? p.ValueSeparators [0]
-					: " ";
-				for (int c = 1; c < p.MaxValueCount; ++c) {
-					Write (o, ref written, localizer (sep + GetArgumentName (c, p.MaxValueCount, p.Description)));
-				}
-				if (p.OptionValueType == OptionValueType.Optional) {
-					Write (o, ref written, localizer ("]"));
-				}
-			}
-			return true;
-		}
-
-		static int GetNextOptionIndex (string[] names, int i)
-		{
-			while (i < names.Length && names [i] == "<>") {
-				++i;
-			}
-			return i;
-		}
-
-		static void Write (TextWriter o, ref int n, string s)
-		{
-			n += s.Length;
-			o.Write (s);
-		}
-
-		private static string GetArgumentName (int index, int maxIndex, string description)
-		{
-			if (description == null)
-				return maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
-			string[] nameStart;
-			if (maxIndex == 1)
-				nameStart = new string[]{"{0:", "{"};
-			else
-				nameStart = new string[]{"{" + index + ":"};
-			for (int i = 0; i < nameStart.Length; ++i) {
-				int start, j = 0;
-				do {
-					start = description.IndexOf (nameStart [i], j);
-				} while (start >= 0 && j != 0 ? description [j++ - 1] == '{' : false);
-				if (start == -1)
-					continue;
-				int end = description.IndexOf ("}", start);
-				if (end == -1)
-					continue;
-				return description.Substring (start + nameStart [i].Length, end - start - nameStart [i].Length);
-			}
-			return maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
-		}
-
-		private static string GetDescription (string description)
-		{
-			if (description == null)
-				return string.Empty;
-			StringBuilder sb = new StringBuilder (description.Length);
-			int start = -1;
-			for (int i = 0; i < description.Length; ++i) {
-				switch (description [i]) {
-					case '{':
-						if (i == start) {
-							sb.Append ('{');
-							start = -1;
-						}
-						else if (start < 0)
-							start = i + 1;
-						break;
-					case '}':
-						if (start < 0) {
-							if ((i+1) == description.Length || description [i+1] != '}')
-								throw new InvalidOperationException ("Invalid option description: " + description);
-							++i;
-							sb.Append ("}");
-						}
-						else {
-							sb.Append (description.Substring (start, i - start));
-							start = -1;
-						}
-						break;
-					case ':':
-						if (start < 0)
-							goto default;
-						start = i + 1;
-						break;
-					default:
-						if (start < 0)
-							sb.Append (description [i]);
-						break;
-				}
-			}
-			return sb.ToString ();
-		}
-
-		private static List<string> GetLines (string description)
-		{
-			List<string> lines = new List<string> ();
-			if (string.IsNullOrEmpty (description)) {
-				lines.Add (string.Empty);
-				return lines;
-			}
-			int length = 80 - OptionWidth - 2;
-			int start = 0, end;
-			do {
-				end = GetLineEnd (start, length, description);
-				bool cont = false;
-				if (end < description.Length) {
-					char c = description [end];
-					if (c == '-' || (char.IsWhiteSpace (c) && c != '\n'))
-						++end;
-					else if (c != '\n') {
-						cont = true;
-						--end;
-					}
-				}
-				lines.Add (description.Substring (start, end - start));
-				if (cont) {
-					lines [lines.Count-1] += "-";
-				}
-				start = end;
-				if (start < description.Length && description [start] == '\n')
-					++start;
-			} while (end < description.Length);
-			return lines;
-		}
-
-		private static int GetLineEnd (int start, int length, string description)
-		{
-			int end = Math.Min (start + length, description.Length);
-			int sep = -1;
-			for (int i = start; i < end; ++i) {
-				switch (description [i]) {
-					case ' ':
-					case '\t':
-					case '\v':
-					case '-':
-					case ',':
-					case '.':
-					case ';':
-						sep = i;
-						break;
-					case '\n':
-						return i;
-				}
-			}
-			if (sep == -1 || end == description.Length)
-				return end;
-			return sep;
-		}
-	}
+internal enum OptionValueType
+{
+    None,
+    Optional,
+    Required,
 }
 
+internal sealed class OptionException : Exception
+{
+    public OptionException()
+    {
+    }
+
+    public OptionException(string? message, string? optionName)
+        : base(message)
+    {
+        OptionName = optionName;
+    }
+
+    public OptionException(string? message, string? optionName, Exception? innerException)
+        : base(message, innerException)
+    {
+        OptionName = optionName;
+    }
+
+    public string? OptionName { get; }
+}
+
+// Backed by a List<string?> internally so the parser can store null sentinel
+// values (the "-a-" minus-suffix path and the optional-with-no-value path both
+// rely on this). The IList<string>/IList faces are kept because tests pin
+// IsFixedSize and ICollection behaviour.
+internal sealed class OptionValueCollection : IList<string>, IList
+{
+    private readonly List<string?> _values = [];
+    private readonly OptionContext _context;
+
+    internal OptionValueCollection(OptionContext context)
+    {
+        _context = context;
+    }
+
+    public int Count => _values.Count;
+
+    public bool IsReadOnly => false;
+
+    public void Add(string item) => _values.Add(item);
+
+    public void Clear() => _values.Clear();
+
+    public bool Contains(string item) => _values.Contains(item);
+
+    public void CopyTo(string[] array, int arrayIndex) =>
+        ((ICollection)_values).CopyTo(array, arrayIndex);
+
+    public bool Remove(string item) => _values.Remove(item);
+
+    public int IndexOf(string item) => _values.IndexOf(item);
+
+    public void Insert(int index, string item) => _values.Insert(index, item);
+
+    public void RemoveAt(int index) => _values.RemoveAt(index);
+
+    // The indexer getter is the contract surface that the OptionSet parser and
+    // user-action lambdas read through. AssertValid runs four distinct checks:
+    //   1. Option not bound       → InvalidOperationException
+    //   2. index ≥ MaxValueCount  → ArgumentOutOfRangeException
+    //   3. Required, no value     → OptionException ("Missing required value")
+    //   4. Optional, no value     → returns null (no throw)
+    // The setter intentionally bypasses AssertValid — that asymmetry is pinned
+    // by tests and is preserved here.
+    public string this[int index]
+    {
+        get
+        {
+            AssertValid(index);
+            return index >= _values.Count ? null! : _values[index]!;
+        }
+        set => _values[index] = value;
+    }
+
+    private void AssertValid(int index)
+    {
+        if (_context.Option is null)
+        {
+            throw new InvalidOperationException("OptionContext.Option is null.");
+        }
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _context.Option.MaxValueCount);
+        if (_context.Option.OptionValueType == OptionValueType.Required && index >= _values.Count)
+        {
+            throw new OptionException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    _context.OptionSet.MessageLocalizer("Missing required value for option '{0}'."),
+                    _context.OptionName),
+                _context.OptionName);
+        }
+    }
+
+    public IEnumerator<string> GetEnumerator()
+    {
+        foreach (var value in _values)
+        {
+            yield return value!;
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => _values.GetEnumerator();
+
+    public List<string> ToList() => new(_values!);
+
+    public string[] ToArray() => _values.ToArray()!;
+
+    public override string ToString() => string.Join(", ", _values);
+
+    bool IList.IsFixedSize => false;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => ((ICollection)_values).SyncRoot;
+
+    void ICollection.CopyTo(Array array, int index) => ((ICollection)_values).CopyTo(array, index);
+
+    object? IList.this[int index]
+    {
+        get => this[index];
+        set => _values[index] = (string?)value;
+    }
+
+    int IList.Add(object? value)
+    {
+        _values.Add((string?)value);
+        return _values.Count - 1;
+    }
+
+    bool IList.Contains(object? value) => _values.Contains((string?)value);
+
+    int IList.IndexOf(object? value) => _values.IndexOf((string?)value);
+
+    void IList.Insert(int index, object? value) => _values.Insert(index, (string?)value);
+
+    void IList.Remove(object? value) => _values.Remove((string?)value);
+
+    void IList.RemoveAt(int index) => _values.RemoveAt(index);
+}
+
+internal sealed class OptionContext
+{
+    public OptionContext(OptionSet set)
+    {
+        ArgumentNullException.ThrowIfNull(set);
+        OptionSet = set;
+        OptionValues = new OptionValueCollection(this);
+    }
+
+    public Option? Option { get; set; }
+
+    public string? OptionName { get; set; }
+
+    public int OptionIndex { get; set; }
+
+    public OptionSet OptionSet { get; }
+
+    public OptionValueCollection OptionValues { get; }
+}
+
+internal abstract class Option
+{
+    private static readonly char[] NameTerminator = ['=', ':'];
+
+    private readonly string[] _names;
+    private string[]? _separators;
+
+    protected Option(string prototype, string? description)
+        : this(prototype, description, 1)
+    {
+    }
+
+    protected Option(string prototype, string? description, int maxValueCount)
+    {
+        ArgumentNullException.ThrowIfNull(prototype);
+        if (prototype.Length == 0)
+        {
+            throw new ArgumentException("Cannot be the empty string.", nameof(prototype));
+        }
+        ArgumentOutOfRangeException.ThrowIfNegative(maxValueCount);
+
+        Prototype = prototype;
+        _names = prototype.Split('|');
+        Description = description;
+        MaxValueCount = maxValueCount;
+        OptionValueType = ParsePrototype();
+
+        if (MaxValueCount == 0 && OptionValueType != OptionValueType.None)
+        {
+            throw new ArgumentException(
+                "Cannot provide maxValueCount of 0 for OptionValueType.Required or OptionValueType.Optional.",
+                nameof(maxValueCount));
+        }
+        if (OptionValueType == OptionValueType.None && maxValueCount > 1)
+        {
+            throw new ArgumentException(
+                $"Cannot provide maxValueCount of {maxValueCount} for OptionValueType.None.",
+                nameof(maxValueCount));
+        }
+        if (Array.IndexOf(_names, "<>") >= 0 &&
+            ((_names.Length == 1 && OptionValueType != OptionValueType.None) ||
+             (_names.Length > 1 && MaxValueCount > 1)))
+        {
+            throw new ArgumentException(
+                "The default option handler '<>' cannot require values.",
+                nameof(prototype));
+        }
+    }
+
+    public string Prototype { get; }
+
+    public string? Description { get; }
+
+    public OptionValueType OptionValueType { get; }
+
+    public int MaxValueCount { get; }
+
+    public string[] GetNames() => (string[])_names.Clone();
+
+    public string[] GetValueSeparators() =>
+        _separators is null ? [] : (string[])_separators.Clone();
+
+    internal string[] Names => _names;
+
+    internal string[]? ValueSeparators => _separators;
+
+    // Uses InvariantCulture (Phase 0 modernisation — the original NDesk code
+    // called ConvertFromString without a culture argument, which silently
+    // defaulted to CurrentCulture and made command-line option parsing depend
+    // on the user's locale).
+    protected static T Parse<T>(string? value, OptionContext c)
+    {
+        var converter = TypeDescriptor.GetConverter(typeof(T));
+        try
+        {
+            if (value is not null)
+            {
+                return (T)converter.ConvertFromString(null!, CultureInfo.InvariantCulture, value)!;
+            }
+        }
+        catch (Exception e)
+        {
+            throw new OptionException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    c.OptionSet.MessageLocalizer("Could not convert string `{0}' to type {1} for option `{2}'."),
+                    value, typeof(T).Name, c.OptionName),
+                c.OptionName,
+                e);
+        }
+        return default!;
+    }
+
+    public void Invoke(OptionContext c)
+    {
+        OnParseComplete(c);
+        c.OptionName = null;
+        c.Option = null;
+        c.OptionValues.Clear();
+    }
+
+    protected abstract void OnParseComplete(OptionContext c);
+
+    public override string ToString() => Prototype;
+
+    private OptionValueType ParsePrototype()
+    {
+        char type = '\0';
+        var separators = new List<string>();
+        for (int i = 0; i < _names.Length; i++)
+        {
+            var name = _names[i];
+            if (name.Length == 0)
+            {
+                throw new ArgumentException("Empty option names are not supported.", nameof(Prototype));
+            }
+
+            int end = name.IndexOfAny(NameTerminator);
+            if (end == -1)
+            {
+                continue;
+            }
+            _names[i] = name[..end];
+            if (type == '\0' || type == name[end])
+            {
+                type = name[end];
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"Conflicting option types: '{type}' vs. '{name[end]}'.",
+                    nameof(Prototype));
+            }
+            AddSeparators(name, end, separators);
+        }
+
+        if (type == '\0')
+        {
+            return OptionValueType.None;
+        }
+
+        if (MaxValueCount <= 1 && separators.Count != 0)
+        {
+            throw new ArgumentException(
+                $"Cannot provide key/value separators for Options taking {MaxValueCount} value(s).",
+                nameof(Prototype));
+        }
+        if (MaxValueCount > 1)
+        {
+            _separators = separators switch
+            {
+                { Count: 0 } => [":", "="],
+                [""] => null,
+                _ => [.. separators],
+            };
+        }
+
+        return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
+    }
+
+    private static void AddSeparators(string name, int end, List<string> separators)
+    {
+        int start = -1;
+        for (int i = end + 1; i < name.Length; i++)
+        {
+            switch (name[i])
+            {
+                case '{':
+                    if (start != -1)
+                    {
+                        throw new ArgumentException(
+                            $"Ill-formed name/value separator found in \"{name}\".",
+                            nameof(name));
+                    }
+                    start = i + 1;
+                    break;
+                case '}':
+                    if (start == -1)
+                    {
+                        throw new ArgumentException(
+                            $"Ill-formed name/value separator found in \"{name}\".",
+                            nameof(name));
+                    }
+                    separators.Add(name[start..i]);
+                    start = -1;
+                    break;
+                default:
+                    if (start == -1)
+                    {
+                        separators.Add(name[i].ToString());
+                    }
+                    break;
+            }
+        }
+        if (start != -1)
+        {
+            throw new ArgumentException(
+                $"Ill-formed name/value separator found in \"{name}\".",
+                nameof(name));
+        }
+    }
+}
+
+internal sealed partial class OptionSet : IEnumerable<Option>
+{
+    // 80-column terminal target. OptionPrototypeColumnWidth is the column at
+    // which descriptions begin; LineWidth-OptionPrototypeColumnWidth-2 is the
+    // wrap point for description text.
+    private const int LineWidth = 80;
+    private const int OptionPrototypeColumnWidth = 29;
+    private const int DescriptionLineWidth = LineWidth - OptionPrototypeColumnWidth - 2;
+    private const string DefaultHandlerName = "<>";
+
+    private readonly List<Option> _options = [];
+    private readonly Dictionary<string, Option> _optionsByName = new(StringComparer.Ordinal);
+
+    public OptionSet()
+        : this(static s => s)
+    {
+    }
+
+    public OptionSet(Func<string, string> localizer)
+    {
+        ArgumentNullException.ThrowIfNull(localizer);
+        MessageLocalizer = localizer;
+    }
+
+    public Func<string, string> MessageLocalizer { get; }
+
+    public int Count => _options.Count;
+
+    public bool Contains(string name) => _optionsByName.ContainsKey(name);
+
+    public Option this[string name]
+    {
+        get
+        {
+            if (!_optionsByName.TryGetValue(name, out var option))
+            {
+                throw new KeyNotFoundException();
+            }
+            return option;
+        }
+    }
+
+    public OptionSet Add(Option option)
+    {
+        ArgumentNullException.ThrowIfNull(option);
+        AddCore(option);
+        return this;
+    }
+
+    public bool Remove(Option option)
+    {
+        ArgumentNullException.ThrowIfNull(option);
+
+        // Capture aliases BEFORE removing — the original NDesk implementation
+        // dereferenced the underlying KeyedCollection's storage AFTER the
+        // base.RemoveItem call, which either threw or returned the wrong item
+        // depending on whether the removed option was last in the list.
+        var aliases = option.Names;
+        if (!_options.Remove(option))
+        {
+            return false;
+        }
+        foreach (var alias in aliases)
+        {
+            _optionsByName.Remove(alias);
+        }
+        return true;
+    }
+
+    private void AddCore(Option option)
+    {
+        // Validate every alias before touching either collection so a partial
+        // failure leaves the set unchanged.
+        foreach (var name in option.Names)
+        {
+            if (_optionsByName.ContainsKey(name))
+            {
+                throw new ArgumentException(
+                    $"Option with name '{name}' already added.",
+                    nameof(option));
+            }
+        }
+
+        _options.Add(option);
+        foreach (var name in option.Names)
+        {
+            _optionsByName[name] = option;
+        }
+    }
+
+    public OptionSet Add(string prototype, Action<string> action) =>
+        Add(prototype, null, action);
+
+    public OptionSet Add(string prototype, string? description, Action<string> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return Add(new ActionOption(prototype, description, 1, values => action(values[0])));
+    }
+
+    public OptionSet Add(string prototype, Action<string, string> action) =>
+        Add(prototype, null, action);
+
+    public OptionSet Add(string prototype, string? description, Action<string, string> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return Add(new ActionOption(prototype, description, 2, values => action(values[0], values[1])));
+    }
+
+    public OptionSet Add<T>(string prototype, Action<T> action) =>
+        Add(prototype, null, action);
+
+    public OptionSet Add<T>(string prototype, string? description, Action<T> action) =>
+        Add(new ActionOption<T>(prototype, description, action));
+
+    public OptionSet Add<TKey, TValue>(string prototype, Action<TKey, TValue> action) =>
+        Add(prototype, null, action);
+
+    public OptionSet Add<TKey, TValue>(string prototype, string? description, Action<TKey, TValue> action) =>
+        Add(new ActionOption<TKey, TValue>(prototype, description, action));
+
+    public IEnumerator<Option> GetEnumerator() => _options.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _options.GetEnumerator();
+
+    // The three private Option subclasses below are the implementations behind
+    // the user-facing Action-based Add overloads. Keeping them nested keeps the
+    // Option public/internal surface limited to the abstract base.
+    private sealed class ActionOption : Option
+    {
+        private readonly Action<OptionValueCollection> _action;
+
+        public ActionOption(string prototype, string? description, int count, Action<OptionValueCollection> action)
+            : base(prototype, description, count)
+        {
+            ArgumentNullException.ThrowIfNull(action);
+            _action = action;
+        }
+
+        protected override void OnParseComplete(OptionContext c) => _action(c.OptionValues);
+    }
+
+    private sealed class ActionOption<T> : Option
+    {
+        private readonly Action<T> _action;
+
+        public ActionOption(string prototype, string? description, Action<T> action)
+            : base(prototype, description, 1)
+        {
+            ArgumentNullException.ThrowIfNull(action);
+            _action = action;
+        }
+
+        protected override void OnParseComplete(OptionContext c) =>
+            _action(Parse<T>(c.OptionValues[0], c));
+    }
+
+    private sealed class ActionOption<TKey, TValue> : Option
+    {
+        private readonly Action<TKey, TValue> _action;
+
+        public ActionOption(string prototype, string? description, Action<TKey, TValue> action)
+            : base(prototype, description, 2)
+        {
+            ArgumentNullException.ThrowIfNull(action);
+            _action = action;
+        }
+
+        protected override void OnParseComplete(OptionContext c) =>
+            _action(
+                Parse<TKey>(c.OptionValues[0], c),
+                Parse<TValue>(c.OptionValues[1], c));
+    }
+
+    private OptionContext CreateOptionContext() => new(this);
+
+    [GeneratedRegex(
+        @"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex OptionTokenPattern();
+
+    public List<string> Parse(IEnumerable<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var context = CreateOptionContext();
+        context.OptionIndex = -1;
+        bool processingOptions = true;
+        var unprocessed = new List<string>();
+        _optionsByName.TryGetValue(DefaultHandlerName, out var defaultHandler);
+
+        foreach (var argument in arguments)
+        {
+            context.OptionIndex++;
+            if (processingOptions && argument == "--")
+            {
+                processingOptions = false;
+                continue;
+            }
+            if (!processingOptions)
+            {
+                RouteUnprocessed(unprocessed, defaultHandler, context, argument);
+                continue;
+            }
+            if (!ParseArgument(argument, context))
+            {
+                RouteUnprocessed(unprocessed, defaultHandler, context, argument);
+            }
+        }
+
+        // Flush any option whose value-collection wasn't satisfied during the
+        // loop (e.g. a required option at the very end of argv with no value).
+        // The OptionException is raised inside the user's action via the
+        // OptionValueCollection indexer's AssertValid path.
+        context.Option?.Invoke(context);
+        return unprocessed;
+    }
+
+    private static void RouteUnprocessed(
+        List<string> unprocessed,
+        Option? defaultHandler,
+        OptionContext context,
+        string argument)
+    {
+        if (defaultHandler is null)
+        {
+            unprocessed.Add(argument);
+            return;
+        }
+        context.OptionValues.Add(argument);
+        context.Option = defaultHandler;
+        defaultHandler.Invoke(context);
+    }
+
+    private bool ParseArgument(string argument, OptionContext context)
+    {
+        // If a previous argument bound a multi-value option that's still
+        // collecting, the current argument is its next value.
+        if (context.Option is not null)
+        {
+            ParseValue(argument, context);
+            return true;
+        }
+
+        var match = OptionTokenPattern().Match(argument);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var flag = match.Groups["flag"].Value;
+        var name = match.Groups["name"].Value;
+        string? separator = match.Groups["sep"].Success ? match.Groups["sep"].Value : null;
+        string? value = match.Groups["value"].Success ? match.Groups["value"].Value : null;
+
+        if (_optionsByName.TryGetValue(name, out var option))
+        {
+            context.OptionName = flag + name;
+            context.Option = option;
+            switch (option.OptionValueType)
+            {
+                case OptionValueType.None:
+                    context.OptionValues.Add(name);
+                    option.Invoke(context);
+                    break;
+                case OptionValueType.Optional:
+                case OptionValueType.Required:
+                    ParseValue(value, context);
+                    break;
+            }
+            return true;
+        }
+
+        return ParseBoolToggle(argument, name, context)
+            || ParseBundle(flag, string.Concat(name, separator, value), context);
+    }
+
+    private void ParseValue(string? value, OptionContext context)
+    {
+        var option = context.Option!;
+        if (value is not null)
+        {
+            var parts = option.ValueSeparators is { } seps
+                ? value.Split(seps, StringSplitOptions.None)
+                : [value];
+            foreach (var part in parts)
+            {
+                context.OptionValues.Add(part);
+            }
+        }
+
+        if (context.OptionValues.Count == option.MaxValueCount ||
+            option.OptionValueType == OptionValueType.Optional)
+        {
+            option.Invoke(context);
+        }
+        else if (context.OptionValues.Count > option.MaxValueCount)
+        {
+            throw new OptionException(
+                MessageLocalizer(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Error: Found {0} option values when expecting {1}.",
+                    context.OptionValues.Count,
+                    option.MaxValueCount)),
+                context.OptionName);
+        }
+    }
+
+    private bool ParseBoolToggle(string argument, string name, OptionContext context)
+    {
+        if (name.Length < 1)
+        {
+            return false;
+        }
+        char suffix = name[^1];
+        if (suffix != '+' && suffix != '-')
+        {
+            return false;
+        }
+
+        var rootName = name[..^1];
+        if (!_optionsByName.TryGetValue(rootName, out var option))
+        {
+            return false;
+        }
+
+        string? value = suffix == '+' ? argument : null;
+        context.OptionName = argument;
+        context.Option = option;
+        context.OptionValues.Add(value!);
+        option.Invoke(context);
+        return true;
+    }
+
+    private bool ParseBundle(string flag, string bundle, OptionContext context)
+    {
+        if (flag != "-")
+        {
+            return false;
+        }
+
+        for (int i = 0; i < bundle.Length; i++)
+        {
+            var optionToken = flag + bundle[i];
+            var character = bundle[i].ToString();
+
+            if (!_optionsByName.TryGetValue(character, out var option))
+            {
+                if (i == 0)
+                {
+                    return false;
+                }
+                throw new OptionException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        MessageLocalizer("Cannot bundle unregistered option '{0}'."),
+                        optionToken),
+                    optionToken);
+            }
+
+            switch (option.OptionValueType)
+            {
+                case OptionValueType.None:
+                    InvokeWithSingleValue(context, optionToken, bundle, option);
+                    break;
+                case OptionValueType.Optional:
+                case OptionValueType.Required:
+                {
+                    var remainder = bundle[(i + 1)..];
+                    context.Option = option;
+                    context.OptionName = optionToken;
+                    ParseValue(remainder.Length != 0 ? remainder : null, context);
+                    return true;
+                }
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown OptionValueType: {option.OptionValueType}");
+            }
+        }
+        return true;
+    }
+
+    private static void InvokeWithSingleValue(OptionContext context, string name, string value, Option option)
+    {
+        context.OptionName = name;
+        context.Option = option;
+        context.OptionValues.Add(value);
+        option.Invoke(context);
+    }
+
+    public void WriteOptionDescriptions(TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        foreach (var option in _options)
+        {
+            int columnsWritten = 0;
+            if (!WriteOptionPrototype(writer, option, MessageLocalizer, ref columnsWritten))
+            {
+                continue;
+            }
+
+            if (columnsWritten < OptionPrototypeColumnWidth)
+            {
+                writer.Write(new string(' ', OptionPrototypeColumnWidth - columnsWritten));
+            }
+            else
+            {
+                writer.WriteLine();
+                writer.Write(new string(' ', OptionPrototypeColumnWidth));
+            }
+
+            var description = MessageLocalizer(NormaliseDescription(option));
+            var lines = WrapDescription(description);
+            writer.WriteLine(lines[0]);
+
+            var continuationIndent = new string(' ', OptionPrototypeColumnWidth + 2);
+            for (int i = 1; i < lines.Count; i++)
+            {
+                writer.Write(continuationIndent);
+                writer.WriteLine(lines[i]);
+            }
+        }
+    }
+
+    private static bool WriteOptionPrototype(
+        TextWriter writer,
+        Option option,
+        Func<string, string> localizer,
+        ref int columnsWritten)
+    {
+        var names = option.Names;
+        int firstVisible = NextVisibleName(names, 0);
+        if (firstVisible == names.Length)
+        {
+            // Option exposes only "<>" → don't render a row at all.
+            return false;
+        }
+
+        var prototypeBuilder = new StringBuilder();
+        AppendName(prototypeBuilder, names[firstVisible], leading: true);
+
+        for (int i = NextVisibleName(names, firstVisible + 1); i < names.Length; i = NextVisibleName(names, i + 1))
+        {
+            prototypeBuilder.Append(", ");
+            AppendName(prototypeBuilder, names[i], leading: false);
+        }
+
+        // The names themselves are NOT routed through the localizer (a translation
+        // of "--verbose" would break CLI parsing). The value tail "[=VALUE]" or
+        // "=VALUE1:VALUE2" IS localized — but as one piece, not fragment-by-fragment
+        // the way the original NDesk code did it.
+        var valueTail = BuildValueTail(option);
+        if (valueTail.Length > 0)
+        {
+            prototypeBuilder.Append(localizer(valueTail));
+        }
+
+        var prototypeText = prototypeBuilder.ToString();
+        writer.Write(prototypeText);
+        columnsWritten += prototypeText.Length;
+        return true;
+
+        static void AppendName(StringBuilder sb, string name, bool leading)
+        {
+            if (leading)
+            {
+                sb.Append(name.Length == 1 ? "  -" : "      --");
+            }
+            else
+            {
+                sb.Append(name.Length == 1 ? "-" : "--");
+            }
+            sb.Append(name);
+        }
+    }
+
+    private static string BuildValueTail(Option option)
+    {
+        if (option.OptionValueType == OptionValueType.None)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        if (option.OptionValueType == OptionValueType.Optional)
+        {
+            builder.Append('[');
+        }
+        builder.Append('=').Append(GetArgumentName(0, option.MaxValueCount, option.Description));
+
+        var separator = option.ValueSeparators is { Length: > 0 } seps ? seps[0] : " ";
+        for (int i = 1; i < option.MaxValueCount; i++)
+        {
+            builder.Append(separator).Append(GetArgumentName(i, option.MaxValueCount, option.Description));
+        }
+
+        if (option.OptionValueType == OptionValueType.Optional)
+        {
+            builder.Append(']');
+        }
+
+        return builder.ToString();
+    }
+
+    private static int NextVisibleName(string[] names, int start)
+    {
+        while (start < names.Length && names[start] == DefaultHandlerName)
+        {
+            start++;
+        }
+        return start;
+    }
+
+    private static string GetArgumentName(int index, int maxIndex, string? description)
+    {
+        if (description is null)
+        {
+            return maxIndex == 1 ? "VALUE" : $"VALUE{index + 1}";
+        }
+
+        // Indexed token "{0:NAME}" wins for multi-value options; bare "{NAME}"
+        // covers the single-value case.
+        string[] tokenStarts = maxIndex == 1
+            ? ["{0:", "{"]
+            : [$"{{{index}:"];
+
+        foreach (var tokenStart in tokenStarts)
+        {
+            int start = -1, scan = 0;
+            do
+            {
+                start = description.IndexOf(tokenStart, scan, StringComparison.Ordinal);
+            }
+            while (start >= 0 && scan != 0 && description[scan++ - 1] == '{');
+
+            if (start == -1)
+            {
+                continue;
+            }
+            int end = description.IndexOf('}', start);
+            if (end == -1)
+            {
+                continue;
+            }
+            return description.Substring(start + tokenStart.Length, end - start - tokenStart.Length);
+        }
+
+        return maxIndex == 1 ? "VALUE" : $"VALUE{index + 1}";
+    }
+
+    private static string NormaliseDescription(Option option)
+    {
+        var description = option.Description;
+        if (string.IsNullOrEmpty(description))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(description.Length);
+        int start = -1;
+        for (int i = 0; i < description.Length; i++)
+        {
+            switch (description[i])
+            {
+                case '{':
+                    if (i == start)
+                    {
+                        sb.Append('{');
+                        start = -1;
+                    }
+                    else if (start < 0)
+                    {
+                        start = i + 1;
+                    }
+                    break;
+                case '}':
+                    if (start < 0)
+                    {
+                        if (i + 1 == description.Length || description[i + 1] != '}')
+                        {
+                            // Phase 0 modernisation: was InvalidOperationException
+                            // with a generic message — FormatException is the
+                            // BCL-conventional choice for malformed input and
+                            // the message identifies the offending option.
+                            throw new FormatException(
+                                $"Unbalanced '}}' in description for option '{option.Prototype}'. Use '}}}}' to escape.");
+                        }
+                        i++;
+                        sb.Append('}');
+                    }
+                    else
+                    {
+                        sb.Append(description.AsSpan(start, i - start));
+                        start = -1;
+                    }
+                    break;
+                case ':':
+                    if (start < 0)
+                    {
+                        goto default;
+                    }
+                    start = i + 1;
+                    break;
+                default:
+                    if (start < 0)
+                    {
+                        sb.Append(description[i]);
+                    }
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static List<string> WrapDescription(string description)
+    {
+        var lines = new List<string>();
+        if (string.IsNullOrEmpty(description))
+        {
+            lines.Add(string.Empty);
+            return lines;
+        }
+
+        int start = 0;
+        while (true)
+        {
+            int end = FindLineBreak(description, start, DescriptionLineWidth);
+            bool needsContinuationDash = false;
+
+            if (end < description.Length)
+            {
+                char terminator = description[end];
+                if (terminator == '-' || (char.IsWhiteSpace(terminator) && terminator != '\n'))
+                {
+                    end++;
+                }
+                else if (terminator != '\n')
+                {
+                    needsContinuationDash = true;
+                    end--;
+                }
+            }
+
+            var line = description[start..end];
+            if (needsContinuationDash)
+            {
+                line += "-";
+            }
+            lines.Add(line);
+
+            start = end;
+            if (start < description.Length && description[start] == '\n')
+            {
+                start++;
+            }
+            if (end >= description.Length)
+            {
+                break;
+            }
+        }
+        return lines;
+    }
+
+    private static int FindLineBreak(string description, int start, int width)
+    {
+        int end = Math.Min(start + width, description.Length);
+        int lastSeparator = -1;
+        for (int i = start; i < end; i++)
+        {
+            switch (description[i])
+            {
+                case ' ':
+                case '\t':
+                case '\v':
+                case '-':
+                case ',':
+                case '.':
+                case ';':
+                    lastSeparator = i;
+                    break;
+                case '\n':
+                    return i;
+            }
+        }
+        return lastSeparator == -1 || end == description.Length ? end : lastSeparator;
+    }
+}

--- a/src/stampver/Stampver.cs
+++ b/src/stampver/Stampver.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using NDesk.Options;
+using stampver.Options;
 
 namespace stampver
 {

--- a/src/stampver/VersionArgs.cs
+++ b/src/stampver/VersionArgs.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
-using NDesk.Options;
+using stampver.Options;
 
 namespace stampver
 {

--- a/src/stampver/stampver.csproj
+++ b/src/stampver/stampver.csproj
@@ -23,7 +23,7 @@
     <NoWarn>$(NoWarn);CS0672;SYSLIB0051;CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8625;CS8769;CA1305;CA1310;CA1507;CA1510;CA1512;CA1716;CA1825;CA1834;CA1846;CA1859;CA1866;CA2208</NoWarn>
     <Authors>Craig Phillips</Authors>
     <Description>Small command-line tool to update AssemblyVersion attributes in .NET projects.</Description>
-    <AssemblyVersion>1.7.0</AssemblyVersion>
+    <AssemblyVersion>1.8.0</AssemblyVersion>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>

--- a/src/stampver/stampver.csproj
+++ b/src/stampver/stampver.csproj
@@ -6,21 +6,6 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Vendored NDesk.Options (Options.cs, ~33KB from 2008) trips a wide range
-         of modern compiler/analyzer diagnostics — obsolete serialization APIs,
-         pre-Nullable patterns, perf rules added since the file was written, etc.
-         We deliberately don't modify it (per CLAUDE.md), so suppress those
-         specific IDs project-wide. Our first-party code has already been
-         cleaned of every diagnostic in this list, so suppressing them here
-         doesn't hide first-party regressions of any current pattern.
-         The list maps to:
-           CS0672 / SYSLIB0051         — obsolete formatter-based serialization
-           CS8600/8601/8602/8603/8604  — nullable reference checks
-           CS8618/8625/8769            — nullable annotation/init checks
-           CA1305/1310/1716            — culture/locale-sensitive APIs
-           CA1507/1510/1512/1825       — modernisation suggestions
-           CA1834/1846/1859/1866/2208  — perf-rule modernisations -->
-    <NoWarn>$(NoWarn);CS0672;SYSLIB0051;CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8625;CS8769;CA1305;CA1310;CA1507;CA1510;CA1512;CA1716;CA1825;CA1834;CA1846;CA1859;CA1866;CA2208</NoWarn>
     <Authors>Craig Phillips</Authors>
     <Description>Small command-line tool to update AssemblyVersion attributes in .NET projects.</Description>
     <AssemblyVersion>1.8.0</AssemblyVersion>


### PR DESCRIPTION
The original `Options.cs` from NDesk has served StampVer well, however, it hasn't been updated since 2008 and now considered to be legacy code.  With the other modernisation refactorings happening across the rest of the StampVer codebase, it's now time to replace `Options.cs` with something more modern.

One option was to use the `System.CommandLine` NuGet package from Microsoft, but that requires taking on a dependency on third-party code.  The other option is to rewrite the `Options.cs` class to use more modern C# idioms whilst also addressing some long-standing bugs and quirks of the code.

This PR rewrites the `Options.cs` class to use more modern C# code.
